### PR TITLE
fix(sidebar): refresh router cache after creating engagement

### DIFF
--- a/src/components/ImportPanel.tsx
+++ b/src/components/ImportPanel.tsx
@@ -69,6 +69,7 @@ export function ImportPanel() {
       }
       const data = await res.json();
       router.push(`/engagements/${data.id}`);
+      router.refresh();
     } catch {
       setError("Failed to import AutoRecon results. Please try again.");
       setFile(null);

--- a/src/components/PastePanel.tsx
+++ b/src/components/PastePanel.tsx
@@ -43,6 +43,7 @@ export function PastePanel() {
       }
       const data = await res.json();
       router.push(`/engagements/${data.id}`);
+      router.refresh();
     } catch {
       setError(
         "Could not parse this input. Paste raw nmap text output or XML (-oN / -oX).",
@@ -63,6 +64,7 @@ export function PastePanel() {
       }
       const data = await res.json();
       router.push(`/engagements/${data.id}`);
+      router.refresh();
     } catch {
       setError("Could not load sample engagement. Please try again.");
     } finally {


### PR DESCRIPTION
## Summary
- Add \`router.refresh()\` after \`router.push()\` in PastePanel and ImportPanel so the sidebar's engagement list reflects the newly created engagement immediately, without requiring a manual F5.
- Server-side \`revalidatePath(\"/\", \"layout\")\` was already correct in \`/api/scan\` and \`/api/sample\`; the missing piece was clearing the *current* client's router cache for the layout segment. Sidebar's clone flow already used this pattern (\`Sidebar.tsx:626-627\`).

Closes #7

## Test plan
- [x] Paste nmap output → sidebar shows new engagement without F5
- [x] Click \"Try sample\" → sidebar shows sample engagement without F5
- [x] AutoRecon ZIP import → sidebar shows imported engagement without F5

🤖 Generated with [Claude Code](https://claude.com/claude-code)