### PR TITLE
feat(tools): relax searchsploit query regex + detect tool paths

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -21,6 +21,7 @@ import { EngagementSettingsList } from "@/components/EngagementSettingsList";
 import { RecycleBinList } from "@/components/RecycleBinList";
 import { EditorIntegrationToggle } from "@/components/EditorIntegrationToggle";
 import { OnboardingSettingsSection } from "@/components/OnboardingSettingsSection";
+import { detectToolPaths } from "@/lib/tool-paths";
 import pkg from "../../../package.json";
 
 export const dynamic = "force-dynamic";
@@ -29,6 +30,7 @@ export default function SettingsIndexPage() {
   const engagements = listSummaries(db);
   const deleted = listDeletedSummaries(db);
   const cfg = effectiveAppState(db);
+  const tools = detectToolPaths();
   const totalHosts = engagements.reduce((acc, e) => acc + e.host_count, 0);
   const totalPorts = engagements.reduce((acc, e) => acc + e.port_count, 0);
 
@@ -77,6 +79,43 @@ export default function SettingsIndexPage() {
             title="KB editor"
             description="Validate and save user knowledge-base entries against the schema. Hot-reloads."
           />
+        </div>
+      </section>
+
+      {/* #9: external tool path detection. Read-only — surfaces what we
+          found at common install locations so operators don't have to
+          hunt for paths. Wordlists/searchsploit defaults can still be
+          overridden via the existing /settings/wordlists editor and the
+          KB lookup binary itself. */}
+      <section style={{ marginBottom: 32 }}>
+        <SectionLabel>Detected tools</SectionLabel>
+        <p
+          style={{
+            fontSize: 12,
+            color: "var(--fg-muted)",
+            margin: "6px 0 12px",
+          }}
+        >
+          Common install locations probed at request time.{" "}
+          <span className="mono">Not found</span> means recon-deck
+          couldn{"’"}t locate the tool — install via apt / git clone
+          or override individual wordlist paths in{" "}
+          <Link
+            href="/settings/wordlists"
+            style={{ color: "var(--accent)", textDecoration: "underline" }}
+          >
+            Wordlists
+          </Link>
+          .
+        </p>
+        <div
+          className="grid grid-cols-1 gap-2"
+          style={{ fontSize: 12.5 }}
+        >
+          <DetectedRow label="searchsploit" value={tools.searchsploit} />
+          <DetectedRow label="SecLists" value={tools.seclists} />
+          <DetectedRow label="dirb wordlists" value={tools.dirb} />
+          <DetectedRow label="dirbuster wordlists" value={tools.dirbuster} />
         </div>
       </section>
 
@@ -165,6 +204,68 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
       style={{ fontSize: 10.5, color: "var(--fg-subtle)" }}
     >
       {children}
+    </div>
+  );
+}
+
+function DetectedRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: { path: string; source: string } | null;
+}) {
+  return (
+    <div
+      className="flex items-center justify-between gap-3"
+      style={{
+        padding: "10px 12px",
+        borderRadius: 6,
+        border: "1px solid var(--border)",
+        background: "var(--bg-2)",
+      }}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          style={{
+            display: "inline-block",
+            width: 8,
+            height: 8,
+            borderRadius: "50%",
+            background: value ? "var(--accent)" : "var(--fg-subtle)",
+            opacity: value ? 1 : 0.5,
+          }}
+        />
+        <span style={{ fontWeight: 500 }}>{label}</span>
+      </div>
+      {value ? (
+        <div className="flex items-center gap-2 min-w-0">
+          <code
+            className="mono truncate"
+            style={{
+              fontSize: 12,
+              color: "var(--fg-muted)",
+              maxWidth: 360,
+            }}
+            title={value.path}
+          >
+            {value.path}
+          </code>
+          <span
+            style={{
+              fontSize: 11,
+              color: "var(--fg-subtle)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {value.source}
+          </span>
+        </div>
+      ) : (
+        <span style={{ fontSize: 12, color: "var(--fg-subtle)" }}>
+          Not found
+        </span>
+      )}
     </div>
   );
 }

--- a/src/lib/exploits/searchsploit.ts
+++ b/src/lib/exploits/searchsploit.ts
@@ -53,13 +53,17 @@ export type SearchsploitResult =
   | { ok: false; error: string };
 
 /**
- * Allowed characters in a search query (T-PR4 — command injection guard).
- * Title-search queries are typically `"vsftpd 3.0.3"` or `"OpenSSH 8.2"` —
- * letters, digits, dots, hyphens, underscores, and spaces cover that
- * vocabulary. Anything else (`;`, `&`, `|`, `$`, backticks, quotes,
- * newlines, …) is rejected outright.
+ * Disallowed characters in a search query (T-PR4 — command injection guard).
+ * Real banners contain slashes, colons, plus signs, parens, commas
+ * (`Apache/2.4.49`, `OpenSSH 7.2p2`, `Samba 3.0.20-Debian`, `Server (Ubuntu)`),
+ * so an allowlist on letters+digits+dots+dashes was rejecting common queries.
+ *
+ * Defense-in-depth: queries are passed via spawn(argv) — never a shell —
+ * so command injection is impossible regardless of content. This regex
+ * blocks the characters that would matter if argv handling ever regressed:
+ * shell metacharacters, quotes, redirection, control chars, newlines.
  */
-const SAFE_QUERY_RE = /^[A-Za-z0-9._\-\s]+$/;
+const UNSAFE_QUERY_RE = /[;&|$`<>"'\\\n\r\t\0]/;
 
 /** Maximum stdout we accept from searchsploit. 10 MB is comfortably above
  * any realistic JSON output (a thousand rows weigh < 500 KB). */
@@ -89,11 +93,12 @@ export function lookupExploits(
   if (trimmed.length > 200) {
     return Promise.resolve({ ok: false, error: "Query is too long (200 char cap)." });
   }
-  if (!SAFE_QUERY_RE.test(trimmed)) {
+  if (UNSAFE_QUERY_RE.test(trimmed)) {
     return Promise.resolve({
       ok: false,
       error:
-        "Query contains disallowed characters (only letters, digits, dot, dash, underscore, space).",
+        "Query contains disallowed characters. Remove shell metacharacters " +
+        "(; & | $ ` < > \" ' \\) and control characters.",
     });
   }
 

--- a/src/lib/tool-paths.ts
+++ b/src/lib/tool-paths.ts
@@ -1,0 +1,115 @@
+import "server-only";
+
+/**
+ * Tool path auto-detection (#9).
+ *
+ * Probes common install locations for the external tools recon-deck talks
+ * to (searchsploit, SecLists, dirb, dirbuster) and reports what was found
+ * so /settings can show "Detected: /usr/share/seclists" instead of making
+ * the operator hunt for paths manually.
+ *
+ * Pure read-only filesystem checks — no spawn, no network. Each probe
+ * returns the first match in priority order; everything else is ignored.
+ */
+
+import { existsSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface DetectedPath {
+  /** Absolute filesystem path that exists. */
+  path: string;
+  /** Human label used in the UI ("Kali default", "PATH", …). */
+  source: string;
+}
+
+export interface ToolPathReport {
+  searchsploit: DetectedPath | null;
+  seclists: DetectedPath | null;
+  dirb: DetectedPath | null;
+  dirbuster: DetectedPath | null;
+}
+
+function fileExists(p: string): boolean {
+  try {
+    return existsSync(p) && statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function dirExists(p: string): boolean {
+  try {
+    return existsSync(p) && statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function detectSearchsploit(): DetectedPath | null {
+  const home = homedir();
+  const candidates: Array<[string, string]> = [
+    ["/usr/local/bin/searchsploit", "Docker image bundle"],
+    ["/usr/bin/searchsploit", "apt (Kali / Debian)"],
+    ["/opt/exploitdb/searchsploit", "git clone"],
+    [join(home, "exploitdb", "searchsploit"), "user home"],
+    [join(home, "tools", "exploitdb", "searchsploit"), "user home"],
+  ];
+  for (const [p, source] of candidates) {
+    if (fileExists(p)) return { path: p, source };
+  }
+  // PATH fallback — first directory containing a searchsploit executable.
+  const pathEnv = process.env.PATH ?? "";
+  for (const dir of pathEnv.split(":").filter(Boolean)) {
+    const p = join(dir, "searchsploit");
+    if (fileExists(p)) return { path: p, source: "PATH" };
+  }
+  return null;
+}
+
+function detectSecLists(): DetectedPath | null {
+  const home = homedir();
+  const candidates: Array<[string, string]> = [
+    ["/usr/share/seclists", "Kali default (apt)"],
+    ["/usr/share/wordlists/seclists", "wordlists/seclists"],
+    ["/opt/SecLists", "/opt"],
+    [join(home, "SecLists"), "user home"],
+    [join(home, "tools", "SecLists"), "user home"],
+  ];
+  for (const [p, source] of candidates) {
+    if (dirExists(p)) return { path: p, source };
+  }
+  return null;
+}
+
+function detectDirb(): DetectedPath | null {
+  const candidates: Array<[string, string]> = [
+    ["/usr/share/dirb/wordlists", "apt (Kali default)"],
+    ["/usr/share/wordlists/dirb", "wordlists/dirb"],
+    ["/usr/local/share/dirb/wordlists", "Homebrew / source"],
+  ];
+  for (const [p, source] of candidates) {
+    if (dirExists(p)) return { path: p, source };
+  }
+  return null;
+}
+
+function detectDirbuster(): DetectedPath | null {
+  const candidates: Array<[string, string]> = [
+    ["/usr/share/dirbuster/wordlists", "apt (Kali default)"],
+    ["/usr/share/wordlists/dirbuster", "wordlists/dirbuster"],
+  ];
+  for (const [p, source] of candidates) {
+    if (dirExists(p)) return { path: p, source };
+  }
+  return null;
+}
+
+export function detectToolPaths(): ToolPathReport {
+  return {
+    searchsploit: detectSearchsploit(),
+    seclists: detectSecLists(),
+    dirb: detectDirb(),
+    dirbuster: detectDirbuster(),
+  };
+}


### PR DESCRIPTION
## Summary
- **#8**: Replace searchsploit query allowlist (\`[A-Za-z0-9._\-\s]\`) with a denylist of shell metacharacters. Real banners like \`Apache/2.4.49\`, \`OpenSSH 7.2p2\`, \`Samba 3.0.20-Debian\`, \`Server (Ubuntu)\` were being rejected. \`spawn(argv)\` is the actual injection boundary — the regex is defense-in-depth.
- **#9**: Add \`src/lib/tool-paths.ts\` that probes common install locations for **searchsploit**, **SecLists**, **dirb wordlists**, and **dirbuster wordlists**. Surface in \`/settings\` → \"Detected tools\" so operators can verify their toolchain at a glance.

Out of scope (follow-up): auto-applying detected SecLists base path to wordlist defaults, settings-side override-from-detection. This PR is detection + display only; overrides still go through \`/settings/wordlists\`.

Closes #8
Closes #9

## Test plan
- [x] \`Apache/2.4.49\` → passes validation (404s on missing binary, not regex)
- [x] \`OpenSSH 7.2p2\` → passes validation
- [x] \`Samba 3.0.20-Debian\` → passes validation
- [x] \`vsftpd; echo pwn\` → still rejected with new error message
- [x] \`/settings\` renders \"Detected tools\" panel with correct Not-found state on macOS dev box
- [ ] On Kali/Docker image: searchsploit detected at \`/usr/local/bin/searchsploit\` with \"Docker image bundle\" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)