### PR TITLE
feat(checklist): bulk Check all / Uncheck all toggle

### DIFF
--- a/app/(app)/engagements/[id]/actions.ts
+++ b/app/(app)/engagements/[id]/actions.ts
@@ -22,6 +22,7 @@ import { redirect } from "next/navigation";
 import {
   db,
   upsertCheck,
+  upsertChecksBatch,
   upsertNote,
   updateTarget,
   deleteEngagement,
@@ -67,6 +68,34 @@ export async function toggleCheck(
     throw new Error("Invalid checkKey.");
   }
   upsertCheck(db, eid, pid, checkKey.trim(), Boolean(checked));
+  revalidatePath(`/engagements/${eid}`);
+}
+
+/**
+ * Bulk-set every checklist item on a port to the same state (#1).
+ *
+ * Powers the "Check all / Uncheck all" header button. One transaction =
+ * one revalidate, so toggling 12 items doesn't fire 12 RSC re-renders.
+ * The per-row ChecklistItem still uses toggleCheck for its useOptimistic
+ * path; this is the bulk shortcut for power users who already have
+ * coverage and want to stamp the whole list at once.
+ */
+export async function setAllChecksForPort(
+  engagementId: number,
+  portId: number,
+  checkKeys: ReadonlyArray<string>,
+  checked: boolean,
+): Promise<void> {
+  const eid = validateId(engagementId, "engagementId");
+  const pid = validateId(portId, "portId");
+  if (!Array.isArray(checkKeys)) {
+    throw new Error("checkKeys must be an array.");
+  }
+  const items = checkKeys
+    .filter((k): k is string => typeof k === "string" && k.trim().length > 0)
+    .map((k) => ({ checkKey: k.trim(), checked: Boolean(checked) }));
+  if (items.length === 0) return;
+  upsertChecksBatch(db, eid, pid, items);
   revalidatePath(`/engagements/${eid}`);
 }
 

--- a/src/components/BulkCheckButton.tsx
+++ b/src/components/BulkCheckButton.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+/**
+ * BulkCheckButton — "Check all / Uncheck all" header shortcut (#1).
+ *
+ * Three states driven by checkedCount vs total:
+ *   0 / N     → "Check all"
+ *   N / N     → "Uncheck all"
+ *   anything  → "Check all" (fills the gaps)
+ *
+ * Server action wraps the whole batch in a transaction so toggling 12
+ * checks fires one revalidate, not twelve. No optimistic state — the
+ * RSC re-render after revalidatePath repaints the per-row checkboxes
+ * fast enough for a single-click bulk action.
+ */
+
+import { useTransition } from "react";
+import { setAllChecksForPort } from "../../app/(app)/engagements/[id]/actions";
+
+export function BulkCheckButton({
+  engagementId,
+  portId,
+  checkKeys,
+  checkedCount,
+}: {
+  engagementId: number;
+  portId: number;
+  checkKeys: ReadonlyArray<string>;
+  checkedCount: number;
+}) {
+  const [pending, startTransition] = useTransition();
+  const total = checkKeys.length;
+  if (total === 0) return null;
+
+  const allChecked = checkedCount === total;
+  const label = allChecked ? "Uncheck all" : "Check all";
+  const next = !allChecked;
+
+  function onClick() {
+    startTransition(async () => {
+      await setAllChecksForPort(engagementId, portId, [...checkKeys], next);
+    });
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={pending}
+      style={{
+        fontSize: 10.5,
+        padding: "2px 8px",
+        height: 20,
+        borderRadius: 4,
+        background: "var(--bg-2)",
+        color: "var(--fg-muted)",
+        border: "1px solid var(--border)",
+        cursor: pending ? "not-allowed" : "pointer",
+        opacity: pending ? 0.5 : 1,
+        textTransform: "uppercase",
+        letterSpacing: "0.06em",
+        fontWeight: 500,
+      }}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/components/PortDetailPane.tsx
+++ b/src/components/PortDetailPane.tsx
@@ -16,6 +16,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { CopyButton } from "@/components/CopyButton";
 import { ChecklistItem } from "@/components/ChecklistItem";
+import { BulkCheckButton } from "@/components/BulkCheckButton";
 import { NotesField } from "@/components/NotesField";
 import { StructuredScriptOutput } from "@/components/StructuredScriptOutput";
 import { EvidencePane } from "@/components/EvidencePane";
@@ -373,6 +374,16 @@ export function PortDetailPane({
         {kbChecks.length > 0 && (
           <Section
             label={`Checklist · ${kbChecks.filter((c) => checkMap.get(c.key)).length}/${kbChecks.length}`}
+            action={
+              <BulkCheckButton
+                engagementId={engagementId}
+                portId={portId}
+                checkKeys={kbChecks.map((c) => c.key)}
+                checkedCount={
+                  kbChecks.filter((c) => checkMap.get(c.key)).length
+                }
+              />
+            }
           >
             <div className="flex flex-col" style={{ gap: 2 }}>
               {kbChecks.map((check) => (
@@ -488,10 +499,12 @@ function CommandCard({ label, command }: { label: string; command: string }) {
 function Section({
   label,
   count,
+  action,
   children,
 }: {
   label: string;
   count?: number;
+  action?: React.ReactNode;
   children: React.ReactNode;
 }) {
   return (
@@ -519,6 +532,7 @@ function Section({
             marginLeft: 6,
           }}
         />
+        {action}
       </div>
       {children}
     </section>

--- a/src/lib/db/checklist-repo.ts
+++ b/src/lib/db/checklist-repo.ts
@@ -59,6 +59,43 @@ export function upsertCheck(
 }
 
 /**
+ * Bulk upsert every (checkKey → checked) pair for one port in a single
+ * transaction. Used by the "Check all / Uncheck all" power-user shortcut
+ * — semantically equivalent to calling `upsertCheck` N times, but one
+ * write barrier means the engagement page revalidates exactly once.
+ */
+export function upsertChecksBatch(
+  db: Db,
+  engagementId: number,
+  portId: number,
+  items: ReadonlyArray<{ checkKey: string; checked: boolean }>,
+): void {
+  if (items.length === 0) return;
+  const now = new Date().toISOString();
+  db.transaction((tx) => {
+    for (const { checkKey, checked } of items) {
+      tx.insert(check_states)
+        .values({
+          engagement_id: engagementId,
+          port_id: portId,
+          check_key: checkKey,
+          checked,
+          updated_at: now,
+        })
+        .onConflictDoUpdate({
+          target: [
+            check_states.engagement_id,
+            check_states.port_id,
+            check_states.check_key,
+          ],
+          set: { checked, updated_at: now },
+        })
+        .run();
+    }
+  });
+}
+
+/**
  * Get all check states for an engagement.
  *
  * Returns all (check_key, checked) pairs across all ports in the engagement.

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -78,7 +78,7 @@ export {
   type AppStatePatch,
   type EffectiveConfig,
 } from "./app-state-repo";
-export { upsertCheck, getChecksByEngagement } from "./checklist-repo";
+export { upsertCheck, upsertChecksBatch, getChecksByEngagement } from "./checklist-repo";
 export { upsertNote, getNotesByEngagement } from "./notes-repo";
 export {
   searchEngagements,


### PR DESCRIPTION
## Summary
Adds a single \`Check all\` / \`Uncheck all\` toggle next to the \"Checklist · X/Y\" header on the port detail pane. Power-user shortcut for ports with many checks where the operator already has bulk coverage.

- **Repo**: new \`upsertChecksBatch\` wraps inserts in a transaction so toggling N items fires one revalidate, not N.
- **Action**: \`setAllChecksForPort\` mirrors \`toggleCheck\`'s validation; dedupes empty keys.
- **UI**: \`Section\` gained an optional \`action\` slot so the button sits inline with the count without rearranging the header.

Closes #1

## Test plan
- [x] Empty checklist → click \"Check all\" → all rows ticked, count flips 0/N → N/N, button label flips to \"Uncheck all\"
- [x] All-checked → click \"Uncheck all\" → all rows cleared, count back to 0/N
- [x] Sidebar engagement progress (e.g. \`0/44\`) updates with the same revalidate
- [x] Per-row \`ChecklistItem\` toggle still works (useOptimistic path unchanged)
- [x] \`vitest\` 471 passing