### PR TITLE
feat(sidebar): collapsible to thin rail with persisted state

### DIFF
--- a/app/(app)/_actions.ts
+++ b/app/(app)/_actions.ts
@@ -1,0 +1,20 @@
+"use server";
+
+/**
+ * Layout-level server actions — mutations that aren't scoped to a single
+ * page (engagement, settings tab) but live on the (app) shell itself.
+ *
+ * Sidebar collapse state is the only one for now; future shell-level
+ * preferences (theme, density) would land here too.
+ */
+
+import { revalidatePath } from "next/cache";
+import { db, setAppState } from "@/lib/db";
+
+export async function setSidebarCollapsed(collapsed: boolean): Promise<void> {
+  if (typeof collapsed !== "boolean") {
+    throw new Error("Invalid value.");
+  }
+  setAppState(db, { sidebar_collapsed: collapsed });
+  revalidatePath("/", "layout");
+}

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -71,6 +71,7 @@ export default function AppLayout({
       <Sidebar
         engagements={engagements}
         schemaVersion={SCHEMA_VERSION_LABEL}
+        collapsed={cfg.sidebarCollapsed}
       />
       {/* `max-width` caps the engagement view on wide monitors. Above
           ~1800px the layout was stretching to the full viewport, leaving

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -13,7 +13,7 @@
  *   6. Footer status bar — offline/local DB indicator.
  */
 
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo, useEffect, useRef, useTransition } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import {
@@ -29,6 +29,8 @@ import {
   Tag as TagIcon,
   Archive,
   ArchiveRestore,
+  PanelLeftClose,
+  PanelLeftOpen,
 } from "lucide-react";
 import { toast } from "sonner";
 import type { EngagementSummary } from "@/lib/db/types";
@@ -36,6 +38,7 @@ import { useUIStore } from "@/lib/store";
 import { DeleteEngagementDialog } from "@/components/DeleteEngagementDialog";
 import { CloneEngagementDialog } from "@/components/CloneEngagementDialog";
 import { RadarMark } from "@/components/RadarMark";
+import { setSidebarCollapsed } from "../../app/(app)/_actions";
 
 export type SidebarEngagement = EngagementSummary & {
   total: number;
@@ -51,9 +54,36 @@ interface SidebarProps {
    * matrix.
    */
   schemaVersion?: string;
+  /** Persisted collapse state from app_state.sidebar_collapsed (#2). */
+  collapsed?: boolean;
 }
 
-export function Sidebar({ engagements, schemaVersion }: SidebarProps) {
+export function Sidebar({
+  engagements,
+  schemaVersion,
+  collapsed = false,
+}: SidebarProps) {
+  const [, startCollapseTransition] = useTransition();
+  function toggleCollapsed() {
+    startCollapseTransition(async () => {
+      await setSidebarCollapsed(!collapsed);
+    });
+  }
+  // Cmd+B / Ctrl+B toggles collapse globally. Skip when modifier-less typing
+  // is happening — the cmd-palette + the engagement search use plain `/`
+  // and `n`, but Cmd+B only fires with the modifier so it never collides.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "b") {
+        e.preventDefault();
+        startCollapseTransition(async () => {
+          await setSidebarCollapsed(!collapsed);
+        });
+      }
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [collapsed]);
   const [filter, setFilter] = useState("");
   // v1.2: view mode (active vs archived) and a multi-select tag filter.
   // Both flow through the same `filtered` memo below so tag chips and the
@@ -179,6 +209,10 @@ export function Sidebar({ engagements, schemaVersion }: SidebarProps) {
     });
   }
 
+  if (collapsed) {
+    return <CollapsedSidebar onExpand={toggleCollapsed} />;
+  }
+
   return (
     <aside
       className="flex h-screen shrink-0 flex-col"
@@ -203,6 +237,24 @@ export function Sidebar({ engagements, schemaVersion }: SidebarProps) {
           >
             recon-deck
           </span>
+          <button
+            type="button"
+            onClick={toggleCollapsed}
+            title="Collapse sidebar (⌘B)"
+            aria-label="Collapse sidebar"
+            className="ml-auto grid place-items-center"
+            style={{
+              width: 22,
+              height: 22,
+              borderRadius: 4,
+              background: "transparent",
+              border: 0,
+              color: "var(--fg-subtle)",
+              cursor: "pointer",
+            }}
+          >
+            <PanelLeftClose size={14} />
+          </button>
         </div>
 
         <Link
@@ -465,6 +517,82 @@ export function Sidebar({ engagements, schemaVersion }: SidebarProps) {
 }
 
 /* ---------------- sub components ---------------- */
+
+function CollapsedSidebar({ onExpand }: { onExpand: () => void }) {
+  return (
+    <aside
+      className="flex h-screen shrink-0 flex-col items-center"
+      style={{
+        width: 52,
+        background: "var(--bg-1)",
+        borderRight: "1px solid var(--border)",
+        padding: "12px 0",
+      }}
+    >
+      <Link
+        href="/"
+        className="grid place-items-center"
+        style={{
+          width: 32,
+          height: 32,
+          borderRadius: 6,
+          textDecoration: "none",
+        }}
+        title="Home"
+      >
+        <RadarMark size={22} contactCount={2} />
+      </Link>
+      <button
+        type="button"
+        onClick={onExpand}
+        title="Expand sidebar (⌘B)"
+        aria-label="Expand sidebar"
+        className="mt-2 grid place-items-center"
+        style={{
+          width: 32,
+          height: 32,
+          borderRadius: 6,
+          border: "1px solid var(--border)",
+          background: "var(--bg-2)",
+          color: "var(--fg-muted)",
+          cursor: "pointer",
+        }}
+      >
+        <PanelLeftOpen size={14} />
+      </button>
+      <div className="mt-auto flex flex-col items-center gap-1">
+        <Link
+          href="/"
+          className="grid place-items-center"
+          style={{
+            width: 32,
+            height: 32,
+            borderRadius: 6,
+            color: "var(--fg-muted)",
+            textDecoration: "none",
+          }}
+          title="New engagement"
+        >
+          <Plus size={14} />
+        </Link>
+        <Link
+          href="/settings"
+          className="grid place-items-center"
+          style={{
+            width: 32,
+            height: 32,
+            borderRadius: 6,
+            color: "var(--fg-muted)",
+            textDecoration: "none",
+          }}
+          title="Settings"
+        >
+          <Cog size={14} />
+        </Link>
+      </div>
+    </aside>
+  );
+}
 
 function SekmeButton({
   active,

--- a/src/lib/db/app-state-repo.ts
+++ b/src/lib/db/app-state-repo.ts
@@ -46,6 +46,7 @@ export interface AppStatePatch {
   kb_user_dir?: string | null;
   wordlist_base?: string | null;
   update_check?: boolean;
+  sidebar_collapsed?: boolean;
 }
 
 /** Partial UPDATE on the singleton; bumps `updated_at` automatically. */
@@ -59,6 +60,8 @@ export function setAppState(db: Db, patch: AppStatePatch): AppState {
   if (patch.wordlist_base !== undefined)
     update.wordlist_base = patch.wordlist_base;
   if (patch.update_check !== undefined) update.update_check = patch.update_check;
+  if (patch.sidebar_collapsed !== undefined)
+    update.sidebar_collapsed = patch.sidebar_collapsed;
 
   db.update(app_state).set(update).where(eq(app_state.id, 1)).run();
   return getAppState(db);
@@ -93,6 +96,7 @@ export interface EffectiveConfig {
   kbUserDir: string | null;
   wordlistBase: string | null;
   updateCheck: boolean;
+  sidebarCollapsed: boolean;
   onboardedAt: string | null;
 }
 
@@ -107,6 +111,7 @@ export function effectiveAppState(db: Db): EffectiveConfig {
     kbUserDir: row.kb_user_dir ?? process.env.RECON_KB_USER_DIR ?? null,
     wordlistBase: row.wordlist_base ?? null,
     updateCheck: row.update_check,
+    sidebarCollapsed: row.sidebar_collapsed,
     onboardedAt: row.onboarded_at,
   };
 }

--- a/src/lib/db/migrations/0019_add-sidebar-collapsed.sql
+++ b/src/lib/db/migrations/0019_add-sidebar-collapsed.sql
@@ -1,0 +1,8 @@
+-- v2.2: persist sidebar collapsed state (#2).
+--
+-- Operators on smaller screens want to free up horizontal real estate by
+-- collapsing the sidebar to a thin rail. Persisting the choice in
+-- app_state means the layout survives navigation + page reloads without
+-- a hydration flash (we read it server-side and SSR the right width).
+
+ALTER TABLE app_state ADD COLUMN sidebar_collapsed INTEGER NOT NULL DEFAULT 0;

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1778800000000,
       "tag": "0018_add-engagement-is-sample",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1778900000000,
+      "tag": "0019_add-sidebar-collapsed",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -735,6 +735,9 @@ export const app_state = sqliteTable("app_state", {
   update_check: integer("update_check", { mode: "boolean" })
     .notNull()
     .default(false),
+  sidebar_collapsed: integer("sidebar_collapsed", { mode: "boolean" })
+    .notNull()
+    .default(false),
   updated_at: text("updated_at").notNull(),
 });
 


### PR DESCRIPTION
## Summary
Adds a sidebar collapse toggle for operators on smaller screens. Two states:
- **Expanded** (260px) — current full engagement list view
- **Collapsed** (52px) — thin icon rail with RadarMark home, expand button, and Plus / Settings icons

State persists in \`app_state.sidebar_collapsed\` so navigation + reloads keep the choice. Server-rendered, so no hydration flash.

### Toggle UX
- \`PanelLeftClose\` icon button in the brand row when expanded
- \`PanelLeftOpen\` icon button on the rail when collapsed
- \`Cmd+B\` / \`Ctrl+B\` global shortcut (no collision — palette uses \`Cmd+K\`)

### Schema
Migration 0019 adds the column with default 0. Schema label in the footer auto-bumps to \`0019\`.

Closes #2

## Test plan
- [x] Click collapse button → sidebar shrinks to 52px rail, content area expands to fill
- [x] Click expand on rail → sidebar restores full engagement list, ACTIVE 11 visible
- [x] Footer shows \`schema 0019\` after migration
- [x] Reload — collapse state persists
- [x] All 471 vitest tests pass
- [x] No hydration flash (SSR uses persisted state)

## Out of scope (follow-up)
- Engagement icons on the rail for one-click switching (the issue mentions this; punted to keep scope tight — rail currently routes through \`/\` for switching)
- Smooth width transition (current implementation snaps; revisit if it bothers users)