### PR TITLE
fix(update-check): differentiate failure modes + stop caching failures

### DIFF
--- a/app/api/update-check/route.ts
+++ b/app/api/update-check/route.ts
@@ -1,5 +1,5 @@
 /**
- * GET /api/update-check — version check against GitHub releases (v1.9.0).
+ * GET /api/update-check — version check against GitHub releases.
  *
  * Honors `app_state.update_check`. When the toggle is OFF the route
  * short-circuits with `{ enabled: false }` so the client never makes the
@@ -9,29 +9,36 @@
  * the bundled package.json version using a naive semver compare (good
  * enough — recon-deck tags are always X.Y.Z without pre-release suffixes).
  *
- * Process-level cache: results are memoized for 1 hour so navigating
- * between pages doesn't fan out to api.github.com on every load.
+ * Process-level cache: only successful results are memoized for 1 hour.
+ * Failures (rate limit, 5xx, network) are never cached, so the next call
+ * always re-attempts — a transient blip can't poison the cache for an hour.
  */
 
 import { NextResponse } from "next/server";
 import { db, effectiveAppState } from "@/lib/db";
 import pkg from "../../../package.json";
 
-interface CacheEntry {
-  fetchedAt: number;
-  payload: UpdateInfo;
-}
+type UpdateInfo =
+  | { enabled: false; current: string }
+  | {
+      enabled: true;
+      ok: true;
+      current: string;
+      latest: string;
+      hasUpdate: boolean;
+      url?: string;
+    }
+  | {
+      enabled: true;
+      ok: false;
+      reason: "github_unavailable" | "rate_limited" | "network_error";
+      current: string;
+    };
 
-interface UpdateInfo {
-  enabled: boolean;
-  current: string;
-  latest?: string;
-  hasUpdate?: boolean;
-  url?: string;
-}
+type SuccessPayload = Extract<UpdateInfo, { enabled: true; ok: true }>;
 
 const CACHE_TTL_MS = 60 * 60 * 1000;
-let cache: CacheEntry | null = null;
+let cache: { fetchedAt: number; payload: SuccessPayload } | null = null;
 
 function compareSemver(a: string, b: string): number {
   const pa = a.replace(/^v/, "").split(".").map((n) => Number(n) || 0);
@@ -49,12 +56,11 @@ export async function GET(req: Request) {
   const force = url.searchParams.get("force") === "1";
 
   const cfg = effectiveAppState(db);
-  // Manual "Check now" (force=1) bypasses both the toggle gate and the
-  // process-level cache. The settings UI uses this to give operators
-  // an explicit way to test the version check without flipping the
-  // automatic toggle on.
   if (!cfg.updateCheck && !force) {
-    return NextResponse.json({ enabled: false, current: pkg.version });
+    return NextResponse.json<UpdateInfo>({
+      enabled: false,
+      current: pkg.version,
+    });
   }
 
   if (!force && cache && Date.now() - cache.fetchedAt < CACHE_TTL_MS) {
@@ -66,21 +72,34 @@ export async function GET(req: Request) {
       "https://api.github.com/repos/kocaemre/recon-deck/releases/latest",
       {
         headers: { Accept: "application/vnd.github+json" },
-        // Edge-runtime safe; node fetch ignores cache.
         cache: "no-store",
       },
     );
     if (!res.ok) {
-      const payload: UpdateInfo = { enabled: true, current: pkg.version };
-      cache = { fetchedAt: Date.now(), payload };
-      return NextResponse.json(payload);
+      const remaining = res.headers.get("x-ratelimit-remaining");
+      const isRateLimited = res.status === 403 && remaining === "0";
+      return NextResponse.json<UpdateInfo>({
+        enabled: true,
+        ok: false,
+        reason: isRateLimited ? "rate_limited" : "github_unavailable",
+        current: pkg.version,
+      });
     }
     const json = (await res.json()) as { tag_name?: string; html_url?: string };
     const latestRaw = json.tag_name ?? "";
     const latest = latestRaw.replace(/^v/, "");
-    const hasUpdate = latest ? compareSemver(latest, pkg.version) > 0 : false;
-    const payload: UpdateInfo = {
+    if (!latest) {
+      return NextResponse.json<UpdateInfo>({
+        enabled: true,
+        ok: false,
+        reason: "github_unavailable",
+        current: pkg.version,
+      });
+    }
+    const hasUpdate = compareSemver(latest, pkg.version) > 0;
+    const payload: SuccessPayload = {
       enabled: true,
+      ok: true,
       current: pkg.version,
       latest,
       hasUpdate,
@@ -89,8 +108,11 @@ export async function GET(req: Request) {
     cache = { fetchedAt: Date.now(), payload };
     return NextResponse.json(payload);
   } catch {
-    const payload: UpdateInfo = { enabled: true, current: pkg.version };
-    cache = { fetchedAt: Date.now(), payload };
-    return NextResponse.json(payload);
+    return NextResponse.json<UpdateInfo>({
+      enabled: true,
+      ok: false,
+      reason: "network_error",
+      current: pkg.version,
+    });
   }
 }

--- a/src/components/OnboardingSettingsSection.tsx
+++ b/src/components/OnboardingSettingsSection.tsx
@@ -58,11 +58,14 @@ export function OnboardingSettingsSection({
     try {
       const res = await fetch("/api/update-check?force=1");
       const data = (await res.json()) as {
+        enabled?: boolean;
+        ok?: boolean;
+        reason?: "github_unavailable" | "rate_limited" | "network_error";
         latest?: string;
         hasUpdate?: boolean;
         url?: string;
       };
-      if (data.hasUpdate && data.latest) {
+      if (data.ok && data.hasUpdate && data.latest) {
         toast(`v${data.latest} available`, {
           description:
             "Re-run the install one-liner (or git pull for local dev) to upgrade — your data stays.",
@@ -75,8 +78,12 @@ export function OnboardingSettingsSection({
               }
             : undefined,
         });
-      } else if (data.latest) {
+      } else if (data.ok && data.latest) {
         toast.success(`You're on the latest version (v${data.latest}).`);
+      } else if (data.reason === "rate_limited") {
+        toast.message("GitHub rate limit hit. Try again in an hour.");
+      } else if (data.reason === "github_unavailable") {
+        toast.message("GitHub returned an error. Try again later.");
       } else {
         toast.message(
           "Could not reach api.github.com. Check your connection or try again later.",


### PR DESCRIPTION
Closes #16.

## Summary
- \`/api/update-check\` now returns a discriminated payload (\`ok: true\` with version data, or \`ok: false\` with \`reason: rate_limited | github_unavailable | network_error\`).
- Rate limit detected via \`403 + x-ratelimit-remaining: 0\`.
- **Failures are no longer cached** — only successful results memo for 1 hour. A transient blip can't poison the cache anymore.
- Settings \"Check now\" toast matches on \`reason\` so users see the actual problem (rate limit / GitHub error) instead of a misleading \"check your connection\".

## Test plan
- [ ] Toggle update check on, click \"Check now\" — success toast with current version.
- [ ] Block \`api.github.com\` → click \"Check now\" → \"Could not reach api.github.com\" toast. Restore network → next click immediately succeeds (no stale cache).
- [ ] \`UpdateAvailableToast\` boot path still tolerates the new shape (it gates on \`enabled && hasUpdate && latest\` which only the success branch sets).