### PR TITLE
fix(tool-paths): docker awareness + /host mount candidates

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -108,6 +108,42 @@ export default function SettingsIndexPage() {
           </Link>
           .
         </p>
+        {tools.inDocker &&
+          !tools.seclists &&
+          !tools.dirb &&
+          !tools.dirbuster && (
+            <div
+              style={{
+                marginBottom: 12,
+                padding: "10px 12px",
+                borderRadius: 6,
+                border: "1px solid var(--border)",
+                background: "var(--bg-2)",
+                fontSize: 12,
+                color: "var(--fg-muted)",
+                lineHeight: 1.5,
+              }}
+            >
+              <div
+                style={{
+                  fontSize: 11,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.06em",
+                  color: "var(--fg-subtle)",
+                  marginBottom: 6,
+                }}
+              >
+                Container detected
+              </div>
+              Host wordlist paths aren{"’"}t visible from inside the
+              recon-deck container without a bind mount. Re-run{" "}
+              <code className="mono">docker run</code> with{" "}
+              <code className="mono">
+                -v /usr/share/wordlists:/host/wordlists:ro
+              </code>{" "}
+              and the rows below will populate.
+            </div>
+          )}
         <div
           className="grid grid-cols-1 gap-2"
           style={{ fontSize: 12.5 }}

--- a/src/lib/tool-paths.ts
+++ b/src/lib/tool-paths.ts
@@ -28,6 +28,17 @@ export interface ToolPathReport {
   seclists: DetectedPath | null;
   dirb: DetectedPath | null;
   dirbuster: DetectedPath | null;
+  /**
+   * True when the Next.js process is running inside a Docker container
+   * (probed via /.dockerenv). When true, host paths like
+   * /usr/share/wordlists/dirb aren't visible without a -v bind mount,
+   * so the UI surfaces a callout instead of all-rows-Not-found.
+   */
+  inDocker: boolean;
+}
+
+function isInDocker(): boolean {
+  return existsSync("/.dockerenv");
 }
 
 function fileExists(p: string): boolean {
@@ -70,8 +81,12 @@ function detectSearchsploit(): DetectedPath | null {
 function detectSecLists(): DetectedPath | null {
   const home = homedir();
   const candidates: Array<[string, string]> = [
+    ["/host/seclists", "Docker host mount"],
+    ["/host/wordlists/seclists", "Docker host mount"],
+    ["/host/wordlists/SecLists", "Docker host mount"],
     ["/usr/share/seclists", "Kali default (apt)"],
     ["/usr/share/wordlists/seclists", "wordlists/seclists"],
+    ["/usr/share/wordlists/SecLists", "wordlists/SecLists"],
     ["/opt/SecLists", "/opt"],
     [join(home, "SecLists"), "user home"],
     [join(home, "tools", "SecLists"), "user home"],
@@ -84,6 +99,8 @@ function detectSecLists(): DetectedPath | null {
 
 function detectDirb(): DetectedPath | null {
   const candidates: Array<[string, string]> = [
+    ["/host/wordlists/dirb", "Docker host mount"],
+    ["/host/dirb", "Docker host mount"],
     ["/usr/share/dirb/wordlists", "apt (Kali default)"],
     ["/usr/share/wordlists/dirb", "wordlists/dirb"],
     ["/usr/local/share/dirb/wordlists", "Homebrew / source"],
@@ -96,6 +113,8 @@ function detectDirb(): DetectedPath | null {
 
 function detectDirbuster(): DetectedPath | null {
   const candidates: Array<[string, string]> = [
+    ["/host/wordlists/dirbuster", "Docker host mount"],
+    ["/host/dirbuster", "Docker host mount"],
     ["/usr/share/dirbuster/wordlists", "apt (Kali default)"],
     ["/usr/share/wordlists/dirbuster", "wordlists/dirbuster"],
   ];
@@ -111,5 +130,6 @@ export function detectToolPaths(): ToolPathReport {
     seclists: detectSecLists(),
     dirb: detectDirb(),
     dirbuster: detectDirbuster(),
+    inDocker: isInDocker(),
   };
 }


### PR DESCRIPTION
Closes #18.

## Summary
- Probe \`/.dockerenv\` and expose \`inDocker\` on the \`ToolPathReport\`.
- SecLists / dirb / dirbuster candidate lists now include \`/host/...\` paths so a \`-v\` bind mount surfaces host wordlists.
- Settings page renders a \"Container detected\" callout (with copy-pasteable \`-v\` snippet) when running inside Docker and none of the three wordlist tools resolve. Discoverable inline instead of in docs.

## Test plan
- [ ] Bare-metal: behavior unchanged, host paths still detected.
- [ ] Docker without mounts → callout visible, three wordlist rows say Not found, searchsploit still detected.
- [ ] Docker with \`-v /usr/share/wordlists:/host/wordlists:ro\` → SecLists/dirb/dirbuster rows populate from \`/host/wordlists/*\`, callout disappears.