### PR TITLE
feat(exploits): auto-fallback to service-only query when version misses

### DIFF
--- a/app/api/exploits/lookup/route.ts
+++ b/app/api/exploits/lookup/route.ts
@@ -35,5 +35,9 @@ export async function POST(request: NextRequest) {
       { status: isBadQuery ? 400 : 503 },
     );
   }
-  return NextResponse.json({ hits: result.hits });
+  return NextResponse.json({
+    hits: result.hits,
+    broaderHits: result.broaderHits,
+    broaderQuery: result.broaderQuery,
+  });
 }

--- a/src/components/PortDetailPane.tsx
+++ b/src/components/PortDetailPane.tsx
@@ -704,7 +704,12 @@ interface ExploitHit {
   url?: string;
 }
 
-const exploitCache = new Map<string, ExploitHit[]>();
+interface ExploitCacheEntry {
+  hits: ExploitHit[];
+  broaderHits?: ExploitHit[];
+  broaderQuery?: string;
+}
+const exploitCache = new Map<string, ExploitCacheEntry>();
 
 function ExploitsSection({
   query,
@@ -719,7 +724,13 @@ function ExploitsSection({
   // searchsploit. Cache key is the verbatim query string (already trimmed
   // by engagement page derivation).
   const cached = exploitCache.get(query) ?? null;
-  const [hits, setHits] = useState<ExploitHit[] | null>(cached);
+  const [hits, setHits] = useState<ExploitHit[] | null>(cached?.hits ?? null);
+  const [broaderHits, setBroaderHits] = useState<ExploitHit[] | null>(
+    cached?.broaderHits ?? null,
+  );
+  const [broaderQuery, setBroaderQuery] = useState<string | null>(
+    cached?.broaderQuery ?? null,
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -736,16 +747,31 @@ function ExploitsSection({
       if (!res.ok) {
         setError(body.error ?? "Lookup failed.");
         setHits(null);
+        setBroaderHits(null);
+        setBroaderQuery(null);
         return;
       }
       const next = Array.isArray(body.hits)
         ? (body.hits as ExploitHit[])
         : [];
-      exploitCache.set(query, next);
+      const broader = Array.isArray(body.broaderHits)
+        ? (body.broaderHits as ExploitHit[])
+        : null;
+      const broaderQ =
+        typeof body.broaderQuery === "string" ? body.broaderQuery : null;
+      exploitCache.set(query, {
+        hits: next,
+        broaderHits: broader ?? undefined,
+        broaderQuery: broaderQ ?? undefined,
+      });
       setHits(next);
+      setBroaderHits(broader);
+      setBroaderQuery(broaderQ);
     } catch (err) {
       setError((err as Error).message ?? "Lookup failed.");
       setHits(null);
+      setBroaderHits(null);
+      setBroaderQuery(null);
     } finally {
       setLoading(false);
     }
@@ -754,7 +780,11 @@ function ExploitsSection({
   return (
     <Section
       label="Exploits"
-      count={hits === null ? undefined : hits.length}
+      count={
+        hits === null
+          ? undefined
+          : hits.length + (broaderHits?.length ?? 0)
+      }
     >
       <div className="flex flex-col gap-2">
         {hits === null && !loading && !error && (
@@ -805,15 +835,18 @@ function ExploitsSection({
           </div>
         )}
 
-        {hits !== null && hits.length === 0 && !loading && (
-          <div
-            className="mono"
-            style={{ fontSize: 11, color: "var(--fg-subtle)" }}
-          >
-            No matches for{" "}
-            <span style={{ color: "var(--accent)" }}>{query}</span>.
-          </div>
-        )}
+        {hits !== null &&
+          hits.length === 0 &&
+          (!broaderHits || broaderHits.length === 0) &&
+          !loading && (
+            <div
+              className="mono"
+              style={{ fontSize: 11, color: "var(--fg-subtle)" }}
+            >
+              No matches for{" "}
+              <span style={{ color: "var(--accent)" }}>{query}</span>.
+            </div>
+          )}
 
         {hits !== null && hits.length > 0 && (
           <ul style={{ margin: 0, padding: 0, listStyle: "none" }}>
@@ -885,6 +918,91 @@ function ExploitsSection({
               </li>
             ))}
           </ul>
+        )}
+
+        {broaderHits && broaderHits.length > 0 && (
+          <div style={{ marginTop: hits && hits.length > 0 ? 10 : 0 }}>
+            <div
+              className="mono uppercase tracking-[0.06em]"
+              style={{
+                fontSize: 10,
+                color: "var(--fg-subtle)",
+                padding: "4px 0",
+              }}
+              title={`Fallback search ran with "${broaderQuery}" because the versioned query had no hits.`}
+            >
+              Broader matches · no version filter (
+              <span style={{ color: "var(--accent)" }}>{broaderQuery}</span>)
+            </div>
+            <ul style={{ margin: 0, padding: 0, listStyle: "none" }}>
+              {broaderHits.map((h) => (
+                <li
+                  key={`broad-${h.id}`}
+                  style={{
+                    padding: "6px 8px",
+                    borderTop: "1px solid var(--border-subtle)",
+                    fontSize: 12,
+                  }}
+                >
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="mono uppercase"
+                      style={{
+                        fontSize: 9.5,
+                        letterSpacing: "0.06em",
+                        padding: "1px 5px",
+                        borderRadius: 3,
+                        background: "var(--bg-3)",
+                        border: "1px solid var(--border)",
+                        color: "var(--fg-muted)",
+                      }}
+                      title={`${h.type} · ${h.platform}`}
+                    >
+                      {h.type}
+                    </span>
+                    <span
+                      style={{ color: "var(--fg)", flex: 1, minWidth: 0 }}
+                    >
+                      {h.title}
+                    </span>
+                    {h.url && (
+                      <a
+                        href={h.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        style={{
+                          color: "var(--accent)",
+                          fontSize: 11,
+                          textDecoration: "none",
+                        }}
+                        title="Open exploit-db entry"
+                      >
+                        EDB-{h.id} ↗
+                      </a>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setFindingPrefill({
+                          title: h.title,
+                          severity: "medium",
+                          cve: extractCve(h.title),
+                          description: `Exploit hit (${h.type} · ${h.platform}) for broader query "${broaderQuery}" (no version filter)\n\n${h.title}${h.url ? `\n${h.url}` : ""}`,
+                          portId,
+                        })
+                      }
+                      title="Add as finding"
+                      aria-label="Add as finding"
+                      style={addFindingBtn}
+                    >
+                      <Plus size={10} />
+                      finding
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
         )}
       </div>
     </Section>

--- a/src/lib/exploits/searchsploit.ts
+++ b/src/lib/exploits/searchsploit.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 /**
- * Local exploit-db lookup via the `searchsploit` binary (P2 candidate).
+ * Local exploit-db lookup via the `searchsploit` binary.
  *
  * Spawns `searchsploit -j -t "<query>"` (title-search, JSON output) and
  * parses the result. The binary ships with Kali Linux's `exploitdb`
@@ -9,22 +9,20 @@ import "server-only";
  * `apt install exploitdb` (Debian/Ubuntu) or fetch the source from
  * https://gitlab.com/exploit-database/exploitdb.
  *
+ * Auto-fallback (#12): searchsploit's title-search uses substring AND
+ * across whitespace-split terms, so `vsftpd 2.3.4` misses real hits like
+ * `vsftpd <= 2.3.5 — Backdoor`. When the primary query returns zero hits
+ * and the query has more than one token, we re-query with just the first
+ * token (service name) and surface that as `broaderHits`. UI renders it
+ * under a "Broader matches" header.
+ *
  * Security:
  *   - `spawn(binary, [args])` with an argv ARRAY — NEVER a shell string.
- *     The query is sanitised against `SAFE_QUERY_RE` before reaching the
- *     subprocess so even if argv shell escaping changes between Node
- *     versions, no metacharacters can flow through.
+ *   - Query sanitised against `UNSAFE_QUERY_RE` (denylist of shell
+ *     metacharacters and control chars).
  *   - Timeout caps wall time at `timeoutMs` (default 5s). On timeout we
- *     SIGKILL and return an error.
- *   - Stdout buffer is capped at 10 MB; oversized output kills the
- *     process and reports an error rather than ballooning heap.
- *   - ENOENT (binary not installed) is reported with an actionable
- *     message rather than a stack trace.
- *
- * The lookup is intentionally synchronous-from-the-caller's perspective
- * (returns Promise<Result>); cache invalidation, debouncing, and result
- * paging are caller concerns. PortDetailPane fires this on a button
- * click so operator-perceived latency stays bounded.
+ *     SIGKILL and return an error. Both queries share the budget.
+ *   - Stdout buffer capped at 10 MB per call.
  */
 
 import { spawn } from "node:child_process";
@@ -32,41 +30,20 @@ import { spawn } from "node:child_process";
 export type ExploitType = "remote" | "local" | "webapp" | "dos" | "shellcode" | string;
 
 export interface ExploitHit {
-  /** exploit-db ID (e.g. "12345"). */
   id: string;
-  /** Title of the entry as exploit-db lists it. */
   title: string;
-  /** "remote" / "local" / "webapp" / "dos" / "shellcode". */
   type: ExploitType;
-  /** Target platform per exploit-db taxonomy ("linux", "windows", "multiple", …). */
   platform: string;
-  /** Publication date (YYYY-MM-DD) when present. */
   date?: string;
-  /** Path inside `/usr/share/exploitdb/exploits/` when present. */
   path?: string;
-  /** exploit-db.com permalink for the entry. */
   url?: string;
 }
 
 export type SearchsploitResult =
-  | { ok: true; hits: ExploitHit[] }
+  | { ok: true; hits: ExploitHit[]; broaderHits?: ExploitHit[]; broaderQuery?: string }
   | { ok: false; error: string };
 
-/**
- * Disallowed characters in a search query (T-PR4 — command injection guard).
- * Real banners contain slashes, colons, plus signs, parens, commas
- * (`Apache/2.4.49`, `OpenSSH 7.2p2`, `Samba 3.0.20-Debian`, `Server (Ubuntu)`),
- * so an allowlist on letters+digits+dots+dashes was rejecting common queries.
- *
- * Defense-in-depth: queries are passed via spawn(argv) — never a shell —
- * so command injection is impossible regardless of content. This regex
- * blocks the characters that would matter if argv handling ever regressed:
- * shell metacharacters, quotes, redirection, control chars, newlines.
- */
 const UNSAFE_QUERY_RE = /[;&|$`<>"'\\\n\r\t\0]/;
-
-/** Maximum stdout we accept from searchsploit. 10 MB is comfortably above
- * any realistic JSON output (a thousand rows weigh < 500 KB). */
 const MAX_STDOUT_BYTES = 10 * 1024 * 1024;
 
 interface RawSearchsploitJson {
@@ -74,49 +51,32 @@ interface RawSearchsploitJson {
 }
 
 export interface LookupOptions {
-  /** Override the binary path (defaults to PATH lookup of `searchsploit`). */
   binary?: string;
-  /** Wall-time cap in ms; default 5000. */
   timeoutMs?: number;
-  /** Cap on returned hits; default 50. */
   limit?: number;
 }
 
-export function lookupExploits(
+type RunResult =
+  | { ok: true; hits: ExploitHit[] }
+  | { ok: false; error: string };
+
+function runSearchsploit(
+  binary: string,
   query: string,
-  opts: LookupOptions = {},
-): Promise<SearchsploitResult> {
-  const trimmed = query.trim();
-  if (!trimmed) {
-    return Promise.resolve({ ok: false, error: "Query is empty." });
-  }
-  if (trimmed.length > 200) {
-    return Promise.resolve({ ok: false, error: "Query is too long (200 char cap)." });
-  }
-  if (UNSAFE_QUERY_RE.test(trimmed)) {
-    return Promise.resolve({
-      ok: false,
-      error:
-        "Query contains disallowed characters. Remove shell metacharacters " +
-        "(; & | $ ` < > \" ' \\) and control characters.",
-    });
-  }
-
-  const binary = opts.binary ?? "searchsploit";
-  const timeoutMs = opts.timeoutMs ?? 5000;
-  const limit = opts.limit ?? 50;
-
-  return new Promise<SearchsploitResult>((resolve) => {
+  timeoutMs: number,
+  limit: number,
+): Promise<RunResult> {
+  return new Promise<RunResult>((resolve) => {
     let settled = false;
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
     let stdoutBytes = 0;
 
-    const proc = spawn(binary, ["-j", "-t", trimmed], {
+    const proc = spawn(binary, ["-j", "-t", query], {
       stdio: ["ignore", "pipe", "pipe"],
     });
 
-    const finalize = (result: SearchsploitResult) => {
+    const finalize = (result: RunResult) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
@@ -170,9 +130,6 @@ export function lookupExploits(
       const stdout = Buffer.concat(stdoutChunks).toString("utf8");
       const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
 
-      // searchsploit exits 0 on success, regardless of whether matches were
-      // found (empty RESULTS_EXPLOIT array). Non-zero with empty stdout =>
-      // surface stderr.
       if (code !== 0 && stdout.length === 0) {
         finalize({
           ok: false,
@@ -212,4 +169,58 @@ export function lookupExploits(
       finalize({ ok: true, hits });
     });
   });
+}
+
+export async function lookupExploits(
+  query: string,
+  opts: LookupOptions = {},
+): Promise<SearchsploitResult> {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return { ok: false, error: "Query is empty." };
+  }
+  if (trimmed.length > 200) {
+    return { ok: false, error: "Query is too long (200 char cap)." };
+  }
+  if (UNSAFE_QUERY_RE.test(trimmed)) {
+    return {
+      ok: false,
+      error:
+        "Query contains disallowed characters. Remove shell metacharacters " +
+        "(; & | $ ` < > \" ' \\) and control characters.",
+    };
+  }
+
+  const binary = opts.binary ?? "searchsploit";
+  const timeoutMs = opts.timeoutMs ?? 5000;
+  const limit = opts.limit ?? 50;
+
+  const primary = await runSearchsploit(binary, trimmed, timeoutMs, limit);
+  if (!primary.ok) return primary;
+
+  // Auto-fallback: if the versioned query produced nothing, retry with the
+  // service-name token alone. Only fires for multi-token queries — a bare
+  // "vsftpd" already represents the broadest sensible search.
+  const tokens = trimmed.split(/\s+/).filter(Boolean);
+  if (primary.hits.length === 0 && tokens.length > 1) {
+    const broaderQuery = tokens[0];
+    if (broaderQuery && !UNSAFE_QUERY_RE.test(broaderQuery)) {
+      const broader = await runSearchsploit(
+        binary,
+        broaderQuery,
+        timeoutMs,
+        limit,
+      );
+      if (broader.ok && broader.hits.length > 0) {
+        return {
+          ok: true,
+          hits: [],
+          broaderHits: broader.hits,
+          broaderQuery,
+        };
+      }
+    }
+  }
+
+  return { ok: true, hits: primary.hits };
 }


### PR DESCRIPTION
Closes #12.

## Summary
- \`lookupExploits\` runs a second searchsploit pass with the first whitespace token alone (the service name) when the primary versioned query returns zero hits. Single-token queries skip the fallback (already broadest).
- New optional fields \`broaderHits\` + \`broaderQuery\` on \`SearchsploitResult\`.
- \`PortDetailPane\` renders broader hits under a \"Broader matches · no version filter\" header with the same row chrome (Add-as-finding included; description notes the broader context).
- Section count badge totals primary + broader.

## Test plan
- [ ] Port banner like \`vsftpd 2.3.4\` → primary empty → \"Broader matches\" surfaces \`vsftpd <= 2.3.5 — Backdoor\` etc.
- [ ] Single-token query (\`vsftpd\`) → no second pass fires; same single list as before.
- [ ] Versioned query that DOES have direct hits → primary list only, no broader section.
- [ ] All 471 existing vitest tests still pass.