### PR TITLE
feat(theme): tri-state light/dark/system mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to recon-deck. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] — 2026-05-07
+
+Minor. Light theme arrives, plus three operator-facing fixes: smarter
+searchsploit fallback, Docker-aware tool detection, and an honest
+update-check error story instead of "Could not reach api.github.com"
+on every transient blip.
+
+### Added
+
+- **Light mode.** Tri-state Display toggle in `/settings` —
+  `system` (default, follows `prefers-color-scheme`), `dark`, and
+  `light`. Tokens flip via `:root.light` overrides on the `<html>`
+  class so component code never branches. Server-side resolution +
+  pre-paint bootstrap script eliminates the theme-flash on hydration.
+  Persisted in `app_state.theme` (migration 0020). Print stylesheet
+  remains light-only regardless of choice. (#3)
+- **searchsploit auto-fallback to service-only query.** When the
+  versioned query (e.g. `vsftpd 2.3.4`) returns zero hits AND has
+  more than one token, recon-deck re-runs with just the first token
+  and surfaces matches under a "Broader matches · no version filter"
+  header. Catches version-range exploits the strict query was
+  silently dropping. (#12)
+
+### Changed
+
+- **`/api/update-check` failure modes are no longer collapsed.** The
+  route now returns `{ ok: false, reason: rate_limited |
+  github_unavailable | network_error }` so the settings "Check now"
+  toast can name the actual problem (rate limit / GitHub side issue)
+  instead of always pointing at the user's network. Failure responses
+  are no longer cached for an hour — the next call always re-attempts
+  so a transient blip can't poison the cache. (#16)
+- **`/settings → Detected tools` is Docker-aware.** Probe `/.dockerenv`
+  and surface a "Container detected" callout with a copy-pasteable
+  `-v /usr/share/wordlists:/host/wordlists:ro` snippet when running
+  inside the recon-deck image with no host mount — instead of the
+  silent all-rows-Not-found that #18 reported. SecLists / dirb /
+  dirbuster candidate lists also probe `/host/...` mount points. (#18)
+
 ## [2.2.0] — 2026-05-03
 
 Minor. Workflow ergonomics: bulk-tick the per-port checklist, collapse

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 Offline. Self-hosted. Every engagement export-ready as Markdown.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.2.0-blue)](CHANGELOG.md)
-[![Schema](https://img.shields.io/badge/schema-0019-orange)](src/lib/db/migrations/)
+[![Version](https://img.shields.io/badge/version-2.3.0-blue)](CHANGELOG.md)
+[![Schema](https://img.shields.io/badge/schema-0020-orange)](src/lib/db/migrations/)
 [![GHCR](https://img.shields.io/badge/ghcr.io-kocaemre%2Frecon--deck-2496ED?logo=docker&logoColor=white)](https://github.com/kocaemre/recon-deck/pkgs/container/recon-deck)
 [![Next.js](https://img.shields.io/badge/Next.js-15.5-black?logo=next.js)](https://nextjs.org)
 [![Offline-first](https://img.shields.io/badge/network-offline_by_default-success)](SECURITY.md)

--- a/app/(app)/settings/_actions.ts
+++ b/app/(app)/settings/_actions.ts
@@ -11,6 +11,7 @@
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { db, replayOnboarding, setAppState } from "@/lib/db";
+import type { ThemeMode } from "@/lib/db/app-state-repo";
 
 export async function replayOnboardingAction(): Promise<void> {
   replayOnboarding(db);
@@ -24,4 +25,13 @@ export async function setUpdateCheckAction(enabled: boolean): Promise<void> {
   }
   setAppState(db, { update_check: enabled });
   revalidatePath("/settings");
+}
+
+export async function setThemeAction(theme: ThemeMode): Promise<void> {
+  if (theme !== "system" && theme !== "dark" && theme !== "light") {
+    throw new Error("Invalid theme.");
+  }
+  setAppState(db, { theme });
+  // Layout-wide because the html className is set in the root layout.
+  revalidatePath("/", "layout");
 }

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -20,6 +20,7 @@ import {
 import { EngagementSettingsList } from "@/components/EngagementSettingsList";
 import { RecycleBinList } from "@/components/RecycleBinList";
 import { EditorIntegrationToggle } from "@/components/EditorIntegrationToggle";
+import { ThemeToggle } from "@/components/ThemeToggle";
 import { OnboardingSettingsSection } from "@/components/OnboardingSettingsSection";
 import { detectToolPaths } from "@/lib/tool-paths";
 import pkg from "../../../package.json";
@@ -170,6 +171,23 @@ export default function SettingsIndexPage() {
             : `${engagements.length} engagement${engagements.length === 1 ? "" : "s"} · ${totalHosts} host${totalHosts === 1 ? "" : "s"} · ${totalPorts} port${totalPorts === 1 ? "" : "s"} total. Use the inline edit on the engagement header to rename.`}
         </p>
         <EngagementSettingsList engagements={engagements} />
+      </section>
+
+      {/* v2.3.0 #3: theme tri-state toggle. */}
+      <section style={{ marginBottom: 32 }}>
+        <SectionLabel>Display</SectionLabel>
+        <p
+          style={{
+            fontSize: 12,
+            color: "var(--fg-muted)",
+            margin: "6px 0 12px",
+          }}
+        >
+          Pick how recon-deck should render. <code className="mono">System</code>{" "}
+          follows your OS preference; explicit choices override it. Print
+          stylesheet always renders light regardless.
+        </p>
+        <ThemeToggle initial={cfg.theme} />
       </section>
 
       {/* v1.4.0 #12: Editor integration toggle. */}

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,7 +3,14 @@
 
 /*
  * recon-deck redesign — Modern IDE / Linear-Raycast polish, terminal-green accent.
- * Dark-mode-only (UI-06). All tokens set at :root, no theme switch.
+ *
+ * Theme model (v2.3.0 #3): tri-state — system / dark / light.
+ *   - Dark is the canonical palette and lives in `:root` (default).
+ *   - Light overrides live under `.light` on the html element.
+ *   - "system" mode resolves to .light or .dark on the server (or via the
+ *     hydration script that reads prefers-color-scheme); the actual class
+ *     written into <html> is always `.dark` or `.light` — never `.system`.
+ *
  * shadcn color aliases are remapped onto the redesign palette so existing
  * shadcn/ui primitives (Button, Card, Dialog, ...) continue to render.
  */
@@ -89,6 +96,57 @@
   /* Shared radius fallback */
   --radius: 6px;
 }
+
+/*
+ * Light-mode palette (v2.3.0 #3).
+ *
+ * Mirrors the dark token surface 1:1 so component code never branches —
+ * the same var(--bg-2) / var(--fg-muted) / var(--accent) calls light up
+ * with light-substrate values. Accent stays terminal-green (slightly
+ * dimmed for AA contrast on white). Risk hues shift toward darker tones
+ * so they read on a near-white card.
+ *
+ * Print stylesheet below already forces white/black, so the operator's
+ * theme choice never bleeds into a printed deliverable.
+ */
+:root.light {
+  /* Surfaces — soft warm whites with stair-stepped greys */
+  --bg-0: #f6f7f9;
+  --bg-1: #ffffff;
+  --bg-2: #f1f2f5;
+  --bg-3: #e6e7eb;
+  --code-surface: #f3f4f6;
+
+  /* Borders */
+  --border: #d8dadf;
+  --border-strong: #b9bcc4;
+  --border-subtle: #e5e6ea;
+
+  /* Text — near-black ramps for AA contrast on bg-1 */
+  --fg: #0f1014;
+  --fg-muted: #494c54;
+  --fg-subtle: #6c707a;
+  --fg-faint: #9da1aa;
+
+  /* Accent — slightly darker green for AA on white */
+  --accent: #15803d;
+  --accent-dim: #166534;
+  --accent-bg: rgba(21, 128, 61, 0.10);
+  --accent-border: rgba(21, 128, 61, 0.35);
+
+  /* Risk palette — deeper hues for legibility on light surfaces */
+  --risk-crit: #b91c1c;
+  --risk-high: #c2410c;
+  --risk-med:  #a16207;
+  --risk-low:  #1d4ed8;
+  --risk-info: #4b5563;
+}
+
+:root.light *::-webkit-scrollbar-thumb {
+  background: #c8cad0;
+  border: 2px solid var(--bg-0);
+}
+:root.light *::-webkit-scrollbar-thumb:hover { background: #a9acb4; }
 
 body {
   background: var(--bg-0);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
+import Script from "next/script";
 import { Toaster } from "sonner";
+import { db, effectiveAppState } from "@/lib/db";
 import "./globals.css";
 
 /**
@@ -17,7 +19,13 @@ import "./globals.css";
  * fetch. Local variable fonts also stop arm64 CI builds from flaking
  * on Google Fonts ETIMEDOUT under QEMU emulation.
  *
- * Dark-mode-only (UI-06). Light theme deferred.
+ * Theme (v2.3.0 #3): app_state.theme is "system" / "dark" / "light".
+ *   - Explicit choice → class is applied server-side.
+ *   - "system" → server renders neutral, an inline pre-paint script
+ *     reads prefers-color-scheme and stamps the right class before
+ *     React hydrates. suppressHydrationWarning swallows the className
+ *     diff that produces. The script is the smallest amount of code
+ *     that prevents a flash of the wrong theme.
  */
 
 const fontUI = localFont({
@@ -44,11 +52,31 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const themePref = effectiveAppState(db).theme;
+  // Server-side resolution: explicit choices stamp their class. "system"
+  // renders without a theme class so the inline script below can pick
+  // it up from prefers-color-scheme before paint.
+  const themeClass =
+    themePref === "dark" ? "dark" : themePref === "light" ? "light" : "";
+
   return (
-    <html lang="en" className={`dark ${fontUI.variable} ${fontMono.variable}`}>
+    <html
+      lang="en"
+      className={`${themeClass} ${fontUI.variable} ${fontMono.variable}`.trim()}
+      data-theme-pref={themePref}
+      suppressHydrationWarning
+    >
+      <head>
+        {/* Static bootstrap script — reads data-theme-pref and resolves
+            "system" via prefers-color-scheme before paint to avoid a
+            theme flash on first hydration. Lives in public/ so the
+            SEC-03 ESLint guard against dangerouslySetInnerHTML stays
+            clean. */}
+        <Script src="/theme-bootstrap.js" strategy="beforeInteractive" />
+      </head>
       <body className="flex h-screen overflow-hidden bg-background text-foreground antialiased">
         {children}
-        <Toaster theme="dark" position="bottom-right" />
+        <Toaster theme={themePref === "system" ? "system" : themePref} position="bottom-right" />
         {/* v2.1.0: desktop-only fallback. CSS shows this block + hides
             everything else when the viewport is < 1280px. recon-deck's
             heatmap layout assumes desktop space — mobile/tablet would

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recon-deck",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/public/theme-bootstrap.js
+++ b/public/theme-bootstrap.js
@@ -1,0 +1,23 @@
+/*
+ * Pre-paint theme bootstrap (v2.3.0 #3).
+ *
+ * Reads `<html data-theme-pref="system|dark|light">` set server-side from
+ * app_state.theme. For explicit choices the server already wrote the
+ * matching class; for "system" we resolve prefers-color-scheme here so
+ * the right palette is on screen before React hydrates — no flash.
+ *
+ * Loaded as a static file (not inline) so the recon-deck ESLint guard
+ * against `dangerouslySetInnerHTML` (SEC-03) stays clean.
+ */
+(function () {
+  try {
+    var html = document.documentElement;
+    var pref = html.getAttribute("data-theme-pref") || "system";
+    if (pref === "system") {
+      var mql = window.matchMedia("(prefers-color-scheme: light)");
+      html.classList.add(mql.matches ? "light" : "dark");
+    }
+  } catch (e) {
+    /* fall through — server class wins */
+  }
+})();

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+/**
+ * ThemeToggle — tri-state (system / dark / light) radio that persists to
+ * app_state.theme via the setThemeAction server action.
+ *
+ * Optimistic UI: we flip the `<html>` className client-side on click for
+ * instant feedback, then call the action which revalidates the layout so
+ * the SSR class on next nav matches. The pre-paint script in the root
+ * layout reads app_state on every server render so OS-prefers changes
+ * survive a refresh.
+ *
+ * Component is a client island purely for the optimistic class flip and
+ * useTransition affordance. Persistence stays server-authoritative.
+ */
+
+import { useState, useTransition } from "react";
+import { Monitor, Moon, Sun } from "lucide-react";
+import { setThemeAction } from "../../app/(app)/settings/_actions";
+import type { ThemeMode } from "../lib/db/app-state-repo";
+
+const OPTIONS: Array<{
+  value: ThemeMode;
+  label: string;
+  icon: typeof Sun;
+  description: string;
+}> = [
+  {
+    value: "system",
+    label: "System",
+    icon: Monitor,
+    description: "Follow the OS prefers-color-scheme setting.",
+  },
+  {
+    value: "dark",
+    label: "Dark",
+    icon: Moon,
+    description: "Always dark — original recon-deck palette.",
+  },
+  {
+    value: "light",
+    label: "Light",
+    icon: Sun,
+    description: "Always light — paired-pentest demos, screen share.",
+  },
+];
+
+function applyClassOptimistic(value: ThemeMode) {
+  const html = document.documentElement;
+  html.classList.remove("dark", "light");
+  if (value === "dark" || value === "light") {
+    html.classList.add(value);
+  } else {
+    const prefersLight = window.matchMedia("(prefers-color-scheme: light)").matches;
+    html.classList.add(prefersLight ? "light" : "dark");
+  }
+  html.dataset.themePref = value;
+}
+
+export function ThemeToggle({ initial }: { initial: ThemeMode }) {
+  const [theme, setTheme] = useState<ThemeMode>(initial);
+  const [pending, startTransition] = useTransition();
+
+  function pick(value: ThemeMode) {
+    if (value === theme) return;
+    const prev = theme;
+    setTheme(value);
+    applyClassOptimistic(value);
+    startTransition(async () => {
+      try {
+        await setThemeAction(value);
+      } catch {
+        setTheme(prev);
+        applyClassOptimistic(prev);
+      }
+    });
+  }
+
+  return (
+    <div
+      style={{
+        padding: "12px 14px",
+        borderRadius: 6,
+        border: "1px solid var(--border)",
+        background: "var(--bg-2)",
+      }}
+    >
+      <div
+        role="radiogroup"
+        aria-label="Theme"
+        className="grid grid-cols-3 gap-2"
+        style={{ marginBottom: 10 }}
+      >
+        {OPTIONS.map((opt) => {
+          const active = theme === opt.value;
+          const Icon = opt.icon;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={() => pick(opt.value)}
+              disabled={pending}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: 6,
+                padding: "10px 8px",
+                borderRadius: 6,
+                border: `1px solid ${active ? "var(--accent-border)" : "var(--border)"}`,
+                background: active ? "var(--accent-bg)" : "var(--bg-1)",
+                color: active ? "var(--accent)" : "var(--fg-muted)",
+                cursor: pending ? "wait" : "pointer",
+                fontSize: 12,
+                fontWeight: 500,
+                opacity: pending ? 0.7 : 1,
+              }}
+            >
+              <Icon size={16} />
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+      <div
+        style={{
+          fontSize: 12,
+          color: "var(--fg-muted)",
+          lineHeight: 1.5,
+        }}
+      >
+        {OPTIONS.find((o) => o.value === theme)?.description}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/db/app-state-repo.ts
+++ b/src/lib/db/app-state-repo.ts
@@ -40,6 +40,8 @@ export function getAppState(db: Db): AppState {
   return row;
 }
 
+export type ThemeMode = "system" | "dark" | "light";
+
 export interface AppStatePatch {
   onboarded_at?: string | null;
   local_export_dir?: string | null;
@@ -47,6 +49,7 @@ export interface AppStatePatch {
   wordlist_base?: string | null;
   update_check?: boolean;
   sidebar_collapsed?: boolean;
+  theme?: ThemeMode;
 }
 
 /** Partial UPDATE on the singleton; bumps `updated_at` automatically. */
@@ -62,6 +65,7 @@ export function setAppState(db: Db, patch: AppStatePatch): AppState {
   if (patch.update_check !== undefined) update.update_check = patch.update_check;
   if (patch.sidebar_collapsed !== undefined)
     update.sidebar_collapsed = patch.sidebar_collapsed;
+  if (patch.theme !== undefined) update.theme = patch.theme;
 
   db.update(app_state).set(update).where(eq(app_state.id, 1)).run();
   return getAppState(db);
@@ -97,7 +101,12 @@ export interface EffectiveConfig {
   wordlistBase: string | null;
   updateCheck: boolean;
   sidebarCollapsed: boolean;
+  theme: ThemeMode;
   onboardedAt: string | null;
+}
+
+function narrowTheme(raw: string): ThemeMode {
+  return raw === "dark" || raw === "light" ? raw : "system";
 }
 
 export function effectiveAppState(db: Db): EffectiveConfig {
@@ -112,6 +121,7 @@ export function effectiveAppState(db: Db): EffectiveConfig {
     wordlistBase: row.wordlist_base ?? null,
     updateCheck: row.update_check,
     sidebarCollapsed: row.sidebar_collapsed,
+    theme: narrowTheme(row.theme),
     onboardedAt: row.onboarded_at,
   };
 }

--- a/src/lib/db/migrations/0020_add-theme.sql
+++ b/src/lib/db/migrations/0020_add-theme.sql
@@ -1,0 +1,8 @@
+-- v2.3.0 #3: persist UI theme preference.
+--
+-- Tri-state — "system" follows prefers-color-scheme (default), "dark" and
+-- "light" are explicit overrides. Stored as TEXT (not enum) because SQLite
+-- doesn't have native enum support; the app-state-repo narrows it to the
+-- ThemeMode union before exposing.
+
+ALTER TABLE app_state ADD COLUMN theme TEXT NOT NULL DEFAULT 'system';

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1778900000000,
       "tag": "0019_add-sidebar-collapsed",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1779000000000,
+      "tag": "0020_add-theme",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -738,6 +738,10 @@ export const app_state = sqliteTable("app_state", {
   sidebar_collapsed: integer("sidebar_collapsed", { mode: "boolean" })
     .notNull()
     .default(false),
+  /** Tri-state — "system" follows prefers-color-scheme, "dark"/"light"
+   *  are explicit user overrides. Stored as TEXT; the repo narrows it
+   *  to the ThemeMode union. v2.3.0 #3. */
+  theme: text("theme").notNull().default("system"),
   updated_at: text("updated_at").notNull(),
 });
 


### PR DESCRIPTION
Closes #3.

## Summary
- Migration 0020: \`app_state.theme TEXT NOT NULL DEFAULT 'system'\`. Repo exposes a narrowed \`ThemeMode\` union via \`EffectiveConfig\`.
- \`:root.light\` token overrides in \`globals.css\` (bg/border/fg/risk). Dark stays canonical — components never branch.
- Root layout SSRs the matching class on \`<html>\`. \`/theme-bootstrap.js\` (Script \`beforeInteractive\`) resolves \`system\` → \`prefers-color-scheme\` before paint to kill the theme-flash. No \`dangerouslySetInnerHTML\` — the SEC-03 ESLint guard stays clean.
- New \`ThemeToggle\` client island in \`/settings → Display\`: tri-state radio with optimistic class flip + \`setThemeAction\` server action.
- Sonner toaster reads the same preference.
- Print stylesheet remains light-only (\`@media print\` overrides regardless of choice).
- README/CHANGELOG bumped: v2.2.0 → v2.3.0, schema 0019 → 0020. CHANGELOG includes #12 / #16 / #18 entries already merged this cycle.

## Browser test
- [x] /settings → Light → page flips, sidebar + heatmap + port detail readable on light substrate.
- [x] Dark → light → dark round-trip, server persists choice across reloads.
- [x] System mode honors OS prefers-color-scheme (verified pre-paint script wires up).
- [x] All 471 vitest tests green, typecheck + ESLint clean.

## Test plan
- [ ] Smoke: \`npm run dev\`, switch all three modes, verify no FOUC and no hydration warning.
- [ ] Verify printed report still renders light when launched from a dark-mode session.
- [ ] First boot on a fresh DB: migration 0020 runs cleanly, \`/settings\` Display shows \`System\` selected.