### PR TITLE
fix(theme): force-dynamic root layout to fix prerender DB read

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -47,12 +47,29 @@ export const metadata: Metadata = {
   description: "nmap output to actionable checklist in under 30 seconds",
 };
 
+// Force dynamic rendering so the root layout reads app_state per-request
+// and never gets baked into a static prerender (which runs at build time
+// before the SQLite file or migrations exist — `/_not-found` was crashing
+// with "no such table: app_state" until this was set).
+export const dynamic = "force-dynamic";
+
+function readThemePref(): "system" | "dark" | "light" {
+  try {
+    return effectiveAppState(db).theme;
+  } catch {
+    // Build-time prerender or first boot before migrations run — fall
+    // back to "system" and let the pre-paint bootstrap script resolve
+    // via prefers-color-scheme.
+    return "system";
+  }
+}
+
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const themePref = effectiveAppState(db).theme;
+  const themePref = readThemePref();
   // Server-side resolution: explicit choices stamp their class. "system"
   // renders without a theme class so the inline script below can pick
   // it up from prefers-color-scheme before paint.


### PR DESCRIPTION
v2.3.0 release build crashed during \`/_not-found\` static prerender — the new root-layout DB read for theme blew up because at Docker build time the SQLite file doesn't exist yet and migrations haven't run.

\`\`\`
SqliteError: no such table: app_state
Export encountered an error on /_not-found/page: /_not-found, exiting the build.
\`\`\`

- \`export const dynamic = \"force-dynamic\"\` on the root layout so it never gets baked into a static page.
- \`readThemePref()\` wraps the DB call in try/catch, defaulting to \`\"system\"\`. The pre-paint bootstrap script handles the rest via \`prefers-color-scheme\`.

Local \`npm run build\` succeeds. Re-tagging \`v2.3.0\` on top of this fix to retrigger the release workflow.