### PR TITLE
feat(parser): autorecon fingerprint extractor (P3 of #14)

### DIFF
--- a/src/lib/db/engagement-repo.ts
+++ b/src/lib/db/engagement-repo.ts
@@ -34,6 +34,7 @@ import type { ParsedScan } from "../parser/types";
 import type { FullEngagement, EngagementSummary, PortWithDetails } from "./types";
 import type * as schema from "./schema";
 import { extractNmapFingerprints } from "../parser/fingerprints";
+import { extractAutoReconFingerprints } from "../parser/autorecon-fingerprints";
 import { replaceForPort as replaceFingerprintsForPort } from "./fingerprints-repo";
 
 /** Drizzle database instance type — inferred from schema for full type safety. */
@@ -246,6 +247,15 @@ export function createFromScan(
                 })
                 .run();
             }
+            // v2.4.0 P3 (#28): derive fingerprints (tech / cves) from the
+            // combined AR file payload for this port. Source is `autorecon`
+            // so a future nmap rescan won't blow these away.
+            replaceFingerprintsForPort(
+              tx,
+              port.id,
+              "autorecon",
+              extractAutoReconFingerprints(files),
+            );
           }
         }
 

--- a/src/lib/parser/__tests__/autorecon-fingerprints.test.ts
+++ b/src/lib/parser/__tests__/autorecon-fingerprints.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractAutoReconFingerprints,
+  type AutoReconFile,
+} from "../autorecon-fingerprints.js";
+
+function file(filename: string, content: string): AutoReconFile {
+  return { filename, content, encoding: "utf8" };
+}
+
+describe("extractAutoReconFingerprints (v2.4.0 P3 #28)", () => {
+  it("returns empty for no files", () => {
+    expect(extractAutoReconFingerprints([])).toEqual([]);
+  });
+
+  describe("shared keyword tagging (whatweb / nikto)", () => {
+    it("tags wordpress + apache from a whatweb plaintext line", () => {
+      const fps = extractAutoReconFingerprints([
+        file(
+          "tcp_80_http_whatweb.txt",
+          "http://10.0.0.1 [200 OK] Apache[2.4.49], WordPress[5.8.1], PHP[7.4.3]",
+        ),
+      ]);
+      const tech = fps.filter((f) => f.type === "tech").map((f) => f.value);
+      expect(tech).toContain("wordpress");
+      expect(tech).toContain("apache");
+      expect(tech).toContain("php");
+    });
+
+    it("dedupes when the same tag is hinted by multiple files", () => {
+      const fps = extractAutoReconFingerprints([
+        file("tcp_80_http_whatweb.txt", "WordPress[5.8]"),
+        file(
+          "tcp_80_http_nikto.txt",
+          "+ Server: Apache\n+ /wp-login.php detected — WordPress",
+        ),
+      ]);
+      const wpCount = fps.filter(
+        (f) => f.type === "tech" && f.value === "wordpress",
+      ).length;
+      expect(wpCount).toBe(1);
+    });
+
+    it("skips base64 files (binary screenshots)", () => {
+      const fps = extractAutoReconFingerprints([
+        {
+          filename: "screenshot-php.png",
+          content: "<<base64-blob-mentioning-php>>",
+          encoding: "base64",
+        },
+      ]);
+      expect(fps).toEqual([]);
+    });
+  });
+
+  describe("CVE extraction", () => {
+    it("pulls CVEs out of nikto output", () => {
+      const fps = extractAutoReconFingerprints([
+        file(
+          "tcp_80_nikto.txt",
+          "+ OSVDB-3268: /icons/: Directory indexing found.\n+ CVE-2021-41773 path traversal",
+        ),
+      ]);
+      const cves = fps.filter((f) => f.type === "cves").map((f) => f.value);
+      expect(cves).toContain("CVE-2021-41773");
+    });
+  });
+
+  describe("feroxbuster extension heuristic", () => {
+    it("tags php when 3+ .php paths appear in feroxbuster output", () => {
+      const lines = [
+        "200      GET    http://10.0.0.1/index.php",
+        "200      GET    http://10.0.0.1/login.php",
+        "200      GET    http://10.0.0.1/admin/dashboard.php",
+        "200      GET    http://10.0.0.1/static/css/site.css",
+      ];
+      const fps = extractAutoReconFingerprints([
+        file("tcp_80_http_feroxbuster.txt", lines.join("\n")),
+      ]);
+      const tech = fps.filter((f) => f.type === "tech").map((f) => f.value);
+      expect(tech).toContain("php");
+    });
+
+    it("skips below-threshold extension counts", () => {
+      const fps = extractAutoReconFingerprints([
+        file(
+          "tcp_80_http_feroxbuster.txt",
+          [
+            "200      GET    http://10.0.0.1/index.php",
+            "200      GET    http://10.0.0.1/static/site.css",
+            "200      GET    http://10.0.0.1/static/site.js",
+          ].join("\n"),
+        ),
+      ]);
+      const tech = fps.filter((f) => f.type === "tech").map((f) => f.value);
+      expect(tech).not.toContain("php");
+    });
+
+    it("only counts URL/path-shaped extensions, not bare words", () => {
+      // The string `php` appears, but no path with `.php` extension —
+      // shouldn't trip the feroxbuster heuristic. Keyword matcher will
+      // still see "php" and tag it via the X-Powered-By needle if
+      // present, but a bare line shouldn't tag from extensions alone.
+      const fps = extractAutoReconFingerprints([
+        file(
+          "tcp_80_feroxbuster.txt",
+          ["[ERROR] could not connect", "Scanning for php files"].join("\n"),
+        ),
+      ]);
+      const techFromFerox = fps.filter(
+        (f) => f.type === "tech" && f.value === "php",
+      );
+      // The keyword matcher *can* tag "php" if 'php' substring matches;
+      // we only want to confirm the extension heuristic isn't the source.
+      // Since the haystack has "php" without a path, the keyword needle
+      // `php/` and `x-powered-by: php` both fail — no tag expected.
+      expect(techFromFerox.length).toBe(0);
+    });
+
+    it("dedupes asp + aspx into a single asp.net tag", () => {
+      const lines = [
+        "200      GET    http://10.0.0.1/login.asp",
+        "200      GET    http://10.0.0.1/admin.asp",
+        "200      GET    http://10.0.0.1/api.aspx",
+        "200      GET    http://10.0.0.1/sso.aspx",
+        "200      GET    http://10.0.0.1/handler.ashx",
+      ];
+      const fps = extractAutoReconFingerprints([
+        file("tcp_443_https_feroxbuster.txt", lines.join("\n")),
+      ]);
+      const aspCount = fps.filter(
+        (f) => f.type === "tech" && f.value === "asp.net",
+      ).length;
+      expect(aspCount).toBe(1);
+    });
+
+    it("filename without a discovery-tool hint does NOT trigger ext tally", () => {
+      // Same content, but filename doesn't match feroxbuster|gobuster|... —
+      // ext tally should not fire. Output may still match keyword needles
+      // (e.g. `php/`); we assert the extension-only signal is absent.
+      const lines = [
+        "/index.php",
+        "/login.php",
+        "/admin.php",
+      ];
+      const fps = extractAutoReconFingerprints([
+        file("tcp_80_curl_output.txt", lines.join("\n")),
+      ]);
+      // `php/` keyword matches (`/index.php` etc. don't satisfy the
+      // exact `php/` needle, only `.php`), so php may or may not appear
+      // — the check here is that the file isn't a discovery tool, so
+      // the heuristic is skipped. We assert no `php` tag to make sure.
+      const tech = fps.filter((f) => f.type === "tech").map((f) => f.value);
+      expect(tech).not.toContain("php");
+    });
+  });
+
+  it("ordering is deterministic: keyword tech, ext-derived tech, cves", () => {
+    const fps = extractAutoReconFingerprints([
+      file("tcp_80_http_whatweb.txt", "Apache[2.4.49]"),
+      file(
+        "tcp_80_http_feroxbuster.txt",
+        ["/a.php", "/b.php", "/c.php"].map((p) => `200 GET http://x${p}`).join("\n"),
+      ),
+      file("tcp_80_http_nikto.txt", "CVE-2021-41773"),
+    ]);
+    // tech first, cves last
+    const tech = fps.filter((f) => f.type === "tech").map((f) => f.value);
+    const cves = fps.filter((f) => f.type === "cves").map((f) => f.value);
+    expect(tech).toContain("apache");
+    expect(tech).toContain("php");
+    expect(cves).toContain("CVE-2021-41773");
+    // Last entry should be a cves entry given our test data.
+    expect(fps[fps.length - 1].type).toBe("cves");
+  });
+});

--- a/src/lib/parser/autorecon-fingerprints.ts
+++ b/src/lib/parser/autorecon-fingerprints.ts
@@ -1,0 +1,165 @@
+/**
+ * AutoRecon fingerprint extractor (v2.4.0 P3 #28).
+ *
+ * Parallels `extractNmapFingerprints` — pure functions, no I/O — but
+ * sources from the per-port AutoRecon files persisted by the importer.
+ * Same `Fingerprint` shape so the resolver (P4) reads both sources
+ * agnostically.
+ *
+ * Heuristics layer on the shared keyword + CVE matchers from
+ * `fingerprints.ts`, then add a feroxbuster/gobuster/dirb extension
+ * heuristic that's specific to web-discovery output: when the bulk of
+ * discovered paths share a runtime extension (`.php`, `.aspx`, `.jsp`),
+ * tag the matching language. This catches PHP/.NET/Java apps even when
+ * whatweb didn't run or the server header was sanitised.
+ *
+ * Conservative on purpose. False positives mean operators see the wrong
+ * conditional checklist; false negatives are recoverable. When in doubt,
+ * drop the signal.
+ */
+
+import { matchCves, matchTechKeywords, type FingerprintType } from "./fingerprints";
+
+export interface AutoReconFingerprint {
+  type: FingerprintType;
+  value: string;
+}
+
+export interface AutoReconFile {
+  filename: string;
+  /** Raw text body (utf8). Binary screenshots etc. should be filtered before. */
+  content: string;
+  encoding?: "utf8" | "base64";
+}
+
+/** Files we recognise as web-discovery tools whose output is a path list. */
+const DISCOVERY_TOOL_RE = /(feroxbuster|gobuster|dirsearch|ffuf|dirb)/i;
+
+/**
+ * Extension → tech tag mapping for the discovery-tool heuristic. Order
+ * doesn't matter; we tally counts and pick the top.
+ */
+const EXT_TECH_MAP: ReadonlyMap<string, string> = new Map([
+  ["php", "php"],
+  ["asp", "asp.net"],
+  ["aspx", "asp.net"],
+  ["ashx", "asp.net"],
+  ["jsp", "java"],
+  ["jspx", "java"],
+  ["do", "java"],
+  ["py", "python"],
+  ["rb", "ruby"],
+  ["cgi", "cgi"],
+]);
+
+/**
+ * Threshold below which an extension hit count is ignored — a single
+ * stray `.php` URL on a static site shouldn't tag the whole port. Tuned
+ * conservatively; the resolver's signal weight is already binary, so a
+ * borderline tag doesn't hurt much.
+ */
+const EXT_HIT_FLOOR = 3;
+
+/**
+ * Walk a discovery-tool output and tally URL path extensions. We only
+ * count tokens that look like a path or URL with an extension; bare
+ * lines like `[ERROR]` get ignored.
+ */
+function tallyExtensions(content: string): Map<string, number> {
+  const tally = new Map<string, number>();
+  // Match path components ending in ".<ext>" where ext is alphanumeric,
+  // bounded by whitespace, line break, query/fragment marker, or quote.
+  const PATH_EXT_RE = /\/[A-Za-z0-9._%~-]+\.([A-Za-z0-9]{1,6})(?=[\s"'?#]|$)/gm;
+  for (const m of content.matchAll(PATH_EXT_RE)) {
+    const ext = m[1].toLowerCase();
+    if (!EXT_TECH_MAP.has(ext)) continue;
+    tally.set(ext, (tally.get(ext) ?? 0) + 1);
+  }
+  return tally;
+}
+
+/**
+ * Promote tallied extensions into tech tags. Counts are summed per-tag
+ * before the threshold check so `asp` + `aspx` + `ashx` collectively
+ * promote `asp.net` even when no single extension reaches the floor on
+ * its own. Iteration order follows `EXT_TECH_MAP` insertion order, so
+ * output is deterministic.
+ */
+function tagsFromExtensionTally(tally: Map<string, number>): string[] {
+  const tagTotals = new Map<string, number>();
+  for (const [ext, count] of tally) {
+    const tag = EXT_TECH_MAP.get(ext);
+    if (!tag) continue;
+    tagTotals.set(tag, (tagTotals.get(tag) ?? 0) + count);
+  }
+  const out: string[] = [];
+  for (const [tag, total] of tagTotals) {
+    if (total >= EXT_HIT_FLOOR) out.push(tag);
+  }
+  return out;
+}
+
+/**
+ * Concatenate every utf8 file's content into a single haystack for the
+ * shared keyword + CVE matchers. Filenames are included so a file like
+ * `tcp_80_http_whatweb.txt` contributes the word "whatweb" to the
+ * haystack — useful when the file body itself is sparse.
+ */
+function buildHaystack(files: ReadonlyArray<AutoReconFile>): string {
+  const parts: string[] = [];
+  for (const f of files) {
+    if (f.encoding === "base64") continue;
+    parts.push(f.filename);
+    parts.push(f.content);
+  }
+  return parts.join("\n").toLowerCase();
+}
+
+/**
+ * Heuristic AutoRecon fingerprint extractor.
+ *
+ * Returns deterministic, deduplicated `AutoReconFingerprint[]`. Tags
+ * derived from the curated keyword list come first; extension-based
+ * tags from web-discovery tools are merged in next (deduplicated against
+ * the keyword tags); CVEs follow last.
+ *
+ * No banner output — banner lines are nmap territory; AutoRecon adds
+ * detail on top.
+ */
+export function extractAutoReconFingerprints(
+  files: ReadonlyArray<AutoReconFile>,
+): AutoReconFingerprint[] {
+  const out: AutoReconFingerprint[] = [];
+  if (files.length === 0) return out;
+
+  const haystack = buildHaystack(files);
+
+  // --- tech via shared keyword list ---
+  const seenTech = new Set<string>();
+  for (const tag of matchTechKeywords(haystack)) {
+    out.push({ type: "tech", value: tag });
+    seenTech.add(tag);
+  }
+
+  // --- tech via discovery-tool extension tally ---
+  const tally = new Map<string, number>();
+  for (const f of files) {
+    if (f.encoding === "base64") continue;
+    if (!DISCOVERY_TOOL_RE.test(f.filename)) continue;
+    for (const [ext, count] of tallyExtensions(f.content)) {
+      tally.set(ext, (tally.get(ext) ?? 0) + count);
+    }
+  }
+  for (const tag of tagsFromExtensionTally(tally)) {
+    if (seenTech.has(tag)) continue;
+    out.push({ type: "tech", value: tag });
+    seenTech.add(tag);
+  }
+
+  // --- CVEs ---
+  for (const cve of matchCves(haystack)) {
+    out.push({ type: "cves", value: cve });
+  }
+
+  return out;
+}

--- a/src/lib/parser/fingerprints.ts
+++ b/src/lib/parser/fingerprints.ts
@@ -33,8 +33,11 @@ export interface NmapFingerprint {
  *
  * Keep this list narrow. Each entry should map to a distinct attack
  * surface that KB authors might want to gate a checklist group on.
+ *
+ * Exported as `TECH_KEYWORDS` so the AutoRecon extractor (P3) can reuse
+ * the same keyword set against whatweb / feroxbuster / nikto outputs.
  */
-const TECH_KEYWORDS: ReadonlyArray<{ tag: string; needles: string[] }> = [
+export const TECH_KEYWORDS: ReadonlyArray<{ tag: string; needles: string[] }> = [
   { tag: "wordpress", needles: ["wordpress"] },
   { tag: "drupal", needles: ["drupal"] },
   { tag: "joomla", needles: ["joomla"] },
@@ -44,7 +47,7 @@ const TECH_KEYWORDS: ReadonlyArray<{ tag: string; needles: string[] }> = [
   { tag: "weblogic", needles: ["weblogic"] },
   { tag: "iis", needles: ["microsoft-iis", "microsoft iis"] },
   { tag: "nginx", needles: ["nginx"] },
-  { tag: "apache", needles: ["apache httpd", "apache/2.", "apache/1."] },
+  { tag: "apache", needles: ["apache httpd", "apache/2.", "apache/1.", "apache["] },
   { tag: "lighttpd", needles: ["lighttpd"] },
   { tag: "openssh", needles: ["openssh"] },
   { tag: "vsftpd", needles: ["vsftpd"] },
@@ -64,14 +67,50 @@ const TECH_KEYWORDS: ReadonlyArray<{ tag: string; needles: string[] }> = [
   { tag: "smb", needles: ["microsoft-ds", "netbios-ssn"] },
   { tag: "rdp", needles: ["ms-wbt-server"] },
   // Languages — usually surface via X-Powered-By or extrainfo.
-  { tag: "php", needles: ["php/", "x-powered-by: php"] },
+  { tag: "php", needles: ["php/", "x-powered-by: php", "php["] },
   { tag: "asp.net", needles: ["asp.net", "x-powered-by: asp.net"] },
   { tag: "node.js", needles: ["node.js", "x-powered-by: express"] },
   { tag: "python", needles: ["werkzeug", "gunicorn", "uvicorn"] },
   { tag: "ruby", needles: ["puma", "passenger phusion", "thin "] },
 ];
 
-const CVE_RE = /CVE-\d{4}-\d{4,7}/gi;
+/** CVE identifier pattern. Exported so P3 reuses the same regex. */
+export const CVE_RE = /CVE-\d{4}-\d{4,7}/gi;
+
+/**
+ * Match the curated tech keyword list against a lower-cased haystack and
+ * return the deduplicated list of tags in the order they first appeared
+ * in `TECH_KEYWORDS`. Shared between the nmap and AutoRecon extractors.
+ */
+export function matchTechKeywords(haystackLower: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const { tag, needles } of TECH_KEYWORDS) {
+    if (seen.has(tag)) continue;
+    if (needles.some((n) => haystackLower.includes(n))) {
+      out.push(tag);
+      seen.add(tag);
+    }
+  }
+  return out;
+}
+
+/**
+ * Pull every CVE identifier out of a haystack, uppercased + deduplicated.
+ * Shared between nmap and AutoRecon extractors.
+ */
+export function matchCves(haystack: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const matches = haystack.match(CVE_RE) ?? [];
+  for (const raw of matches) {
+    const upper = raw.toUpperCase();
+    if (seen.has(upper)) continue;
+    out.push(upper);
+    seen.add(upper);
+  }
+  return out;
+}
 
 /**
  * Build the haystack used for tech / CVE matching from a single port row.
@@ -119,27 +158,12 @@ export function extractNmapFingerprints(port: ParsedPort): NmapFingerprint[] {
   const out: NmapFingerprint[] = [];
   const haystack = buildHaystack(port);
 
-  // --- tech ---
-  const seenTech = new Set<string>();
-  for (const { tag, needles } of TECH_KEYWORDS) {
-    if (seenTech.has(tag)) continue;
-    if (needles.some((n) => haystack.includes(n))) {
-      out.push({ type: "tech", value: tag });
-      seenTech.add(tag);
-    }
+  for (const tag of matchTechKeywords(haystack)) {
+    out.push({ type: "tech", value: tag });
   }
-
-  // --- CVEs ---
-  const seenCves = new Set<string>();
-  const cveMatches = haystack.match(CVE_RE) ?? [];
-  for (const raw of cveMatches) {
-    const upper = raw.toUpperCase();
-    if (seenCves.has(upper)) continue;
-    out.push({ type: "cves", value: upper });
-    seenCves.add(upper);
+  for (const cve of matchCves(haystack)) {
+    out.push({ type: "cves", value: cve });
   }
-
-  // --- banner ---
   const banner = extractBanner(port);
   if (banner) out.push({ type: "banners", value: banner });
 


### PR DESCRIPTION
Third phase of #14 (\`v2.4.0\` milestone). Closes #28.

Mirrors P2 (#32) for the AutoRecon side — same shape, same persistence layer, different source.

## Summary

- **Refactor** \`fingerprints.ts\`: hoisted \`matchTechKeywords\` and \`matchCves\` so the AR extractor reuses the same keyword list + regex. Whatweb bracket-format needles added (\`apache[\`, \`php[\`) so plaintext whatweb lines tag correctly.
- **New extractor** \`autorecon-fingerprints.ts\`:
  - Combines all utf8 file content + filenames into one haystack for shared keyword + CVE matching.
  - **Discovery-tool extension heuristic**: scan files matching \`feroxbuster|gobuster|dirsearch|ffuf|dirb\` for URL paths ending in known runtime extensions, tag the corresponding tech when the per-tag sum clears \`EXT_HIT_FLOOR = 3\`. Summing per-tag means \`asp + aspx + ashx\` collectively promote \`asp.net\`.
  - Filename gating ensures the heuristic doesn't fire on arbitrary curl output that happens to contain \`.php\` paths.
  - Base64 entries (binary screenshots) skipped.
- **Wiring**: \`engagement-repo.createFromScan\` writes \`source: autorecon\` rows after AR files are persisted, same transaction.

## Test plan
- [x] \`npm run test\` — 508 pass (was 497; +11 new cases).
- [x] \`npm run typecheck\` clean.
- [x] ESLint clean.
- [ ] Smoke: import an AutoRecon zip with a feroxbuster output containing 5+ \`.php\` paths, verify a \`port_fingerprints (source=autorecon, type=tech, value=php)\` row appears.
- [ ] Mixed re-import: nmap rescan after AR import — \`source=autorecon\` rows untouched (P2 \`replaceForPort\` only deletes \`source=nmap\`).

## What's next
- **#29 (P4)**: resolver evaluating the \`when\` DSL against persisted fingerprints + raw nmap data.
- **#30 (P5)**: UI provenance badges.