### PR TITLE
feat(ui): conditional checklist + command provenance badges (P5 of #14)

### DIFF
--- a/app/(app)/engagements/[id]/page.tsx
+++ b/app/(app)/engagements/[id]/page.tsx
@@ -282,16 +282,28 @@ export default async function EngagementPage({
     };
     const resolved = applyConditionals(kbEntry, resolveCtx);
 
-    const kbCommands = resolved.commands.map((cmd) => ({
-      label: cmd.label,
-      command: interpolateCommand(
-        cmd.template,
-        targetIp,
-        p.port,
-        targetHostname,
-        wordlistOverrides,
-      ),
-    }));
+    const kbCommands = resolved.commands.map((cmd) => {
+      // v2.4.0 P5 (#30): surface which conditionals modified this
+      // command so PortDetailPane can render the "+id" provenance pill.
+      // Replace contributors come first (the heavy hammer), appends
+      // follow in declaration order to mirror how the template was
+      // assembled.
+      const ids = [
+        ...(cmd.replacedBy ? [cmd.replacedBy] : []),
+        ...cmd.appendedBy,
+      ];
+      return {
+        label: cmd.label,
+        command: interpolateCommand(
+          cmd.template,
+          targetIp,
+          p.port,
+          targetHostname,
+          wordlistOverrides,
+        ),
+        ...(ids.length > 0 ? { conditionalIds: ids } : {}),
+      };
+    });
 
     // v2/P0-D: merge user-defined snippets that match this (service, port).
     const userMatches = matchUserCommands(db, p.service ?? null, p.port);
@@ -305,7 +317,42 @@ export default async function EngagementPage({
         wordlistOverrides,
       ),
     }));
-    const kbChecks = resolved.checks.map((c) => ({ key: c.key, label: c.label }));
+    // v2.4.0 P5 (#30): map resolved checks to wire format + reconcile
+    // orphans. A check is orphan when an inactive conditional declared
+    // its key AND the operator already toggled it (check_states row
+    // exists) — preserves UX continuity when a signal drops out (e.g.
+    // re-import lost the http-server-header line) without silently
+    // discarding the operator's prior work.
+    const checkKeysWithState = new Set(p.checks.map((c) => c.check_key));
+    const seenCheckKeys = new Set<string>();
+    const kbChecks: Array<{
+      key: string;
+      label: string;
+      source: "baseline" | "conditional" | "orphan";
+      conditionalId?: string;
+    }> = [];
+    for (const c of resolved.checks) {
+      seenCheckKeys.add(c.key);
+      kbChecks.push({
+        key: c.key,
+        label: c.label,
+        source: c.source,
+        ...(c.conditionalId ? { conditionalId: c.conditionalId } : {}),
+      });
+    }
+    for (const inactive of resolved.inactive) {
+      for (const orphanCheck of inactive.adds_checks) {
+        if (!checkKeysWithState.has(orphanCheck.key)) continue;
+        if (seenCheckKeys.has(orphanCheck.key)) continue;
+        kbChecks.push({
+          key: orphanCheck.key,
+          label: orphanCheck.label,
+          source: "orphan",
+          conditionalId: inactive.id,
+        });
+        seenCheckKeys.add(orphanCheck.key);
+      }
+    }
     const kbResources = kbEntry.resources.map((r) => ({
       title: r.title,
       url: r.url,

--- a/src/components/PortDetailPane.tsx
+++ b/src/components/PortDetailPane.tsx
@@ -71,8 +71,27 @@ interface PortDetailPaneProps {
   scripts: ScriptData[];
   checks: Array<{ check_key: string; checked: boolean }>;
   notes: { body: string } | null;
-  kbCommands: Array<{ label: string; command: string }>;
-  kbChecks: Array<{ key: string; label: string }>;
+  kbCommands: Array<{
+    label: string;
+    command: string;
+    /** v2.4.0 P5 (#30): conditional ids that modified this command's
+     *  template (append + replace contributors). Surfaces the "+detected: X"
+     *  badge next to the command label so operators understand why the
+     *  rendered template differs from the baseline KB. */
+    conditionalIds?: string[];
+  }>;
+  kbChecks: Array<{
+    key: string;
+    label: string;
+    /** v2.4.0 P5 (#30): provenance for the checklist row.
+     *  - "baseline" → from KB entry's checks[] (default when omitted)
+     *  - "conditional" → added by a fired conditional this render
+     *  - "orphan" → previously added by a conditional that's no longer
+     *    matching, but the operator's toggle state survived in the DB */
+    source?: "baseline" | "conditional" | "orphan";
+    /** Set when source ∈ {"conditional", "orphan"}. Drives the badge label. */
+    conditionalId?: string;
+  }>;
   kbResources: Array<{ title: string; url: string }>;
   arFiles?: Array<{ filename: string; content: string; encoding?: "utf8" | "base64" }>;
   arCommands?: Array<{ label: string; command: string }>;
@@ -261,7 +280,12 @@ export function PortDetailPane({
           <Section label="Commands" count={kbCommands.length}>
             <div className="flex flex-col gap-2">
               {kbCommands.map((cmd, i) => (
-                <CommandCard key={i} label={cmd.label} command={cmd.command} />
+                <CommandCard
+                  key={i}
+                  label={cmd.label}
+                  command={cmd.command}
+                  conditionalIds={cmd.conditionalIds}
+                />
               ))}
             </div>
           </Section>
@@ -386,16 +410,61 @@ export function PortDetailPane({
             }
           >
             <div className="flex flex-col" style={{ gap: 2 }}>
-              {kbChecks.map((check) => (
-                <ChecklistItem
-                  key={check.key}
-                  engagementId={engagementId}
-                  portId={portId}
-                  checkKey={check.key}
-                  initialChecked={checkMap.get(check.key) === true}
-                  label={check.label}
-                />
-              ))}
+              {(() => {
+                // v2.4.0 P5 (#30): group checks by provenance so the
+                // baseline list reads cleanly and conditional / orphan
+                // rows render below a subtle separator. Within each
+                // group rows preserve the order the resolver emitted.
+                const baseline = kbChecks.filter(
+                  (c) => !c.source || c.source === "baseline",
+                );
+                const conditional = kbChecks.filter(
+                  (c) => c.source === "conditional",
+                );
+                const orphan = kbChecks.filter((c) => c.source === "orphan");
+                return (
+                  <>
+                    {baseline.map((check) => (
+                      <ChecklistItem
+                        key={check.key}
+                        engagementId={engagementId}
+                        portId={portId}
+                        checkKey={check.key}
+                        initialChecked={checkMap.get(check.key) === true}
+                        label={check.label}
+                      />
+                    ))}
+                    {conditional.length > 0 && (
+                      <ConditionalGroupHeader label="Context-specific" />
+                    )}
+                    {conditional.map((check) => (
+                      <ConditionalChecklistRow
+                        key={check.key}
+                        engagementId={engagementId}
+                        portId={portId}
+                        check={check}
+                        initialChecked={checkMap.get(check.key) === true}
+                      />
+                    ))}
+                    {orphan.length > 0 && (
+                      <ConditionalGroupHeader
+                        label="Orphaned · signal no longer present"
+                        muted
+                      />
+                    )}
+                    {orphan.map((check) => (
+                      <ConditionalChecklistRow
+                        key={check.key}
+                        engagementId={engagementId}
+                        portId={portId}
+                        check={check}
+                        initialChecked={checkMap.get(check.key) === true}
+                        orphan
+                      />
+                    ))}
+                  </>
+                );
+              })()}
             </div>
           </Section>
         )}
@@ -456,7 +525,15 @@ export function PortDetailPane({
   );
 }
 
-function CommandCard({ label, command }: { label: string; command: string }) {
+function CommandCard({
+  label,
+  command,
+  conditionalIds,
+}: {
+  label: string;
+  command: string;
+  conditionalIds?: string[];
+}) {
   return (
     <div
       style={{
@@ -467,7 +544,7 @@ function CommandCard({ label, command }: { label: string; command: string }) {
       }}
     >
       <div
-        className="flex items-center"
+        className="flex items-center gap-2"
         style={{
           padding: "4px 10px",
           borderBottom: "1px solid var(--border)",
@@ -475,6 +552,9 @@ function CommandCard({ label, command }: { label: string; command: string }) {
         }}
       >
         <span style={{ fontSize: 11, color: "var(--fg-muted)" }}>{label}</span>
+        {conditionalIds && conditionalIds.length > 0 && (
+          <ProvenanceBadge ids={conditionalIds} />
+        )}
         <span className="ml-auto">
           <CopyButton text={command} label={command} />
         </span>
@@ -492,6 +572,114 @@ function CommandCard({ label, command }: { label: string; command: string }) {
         <span style={{ color: "var(--accent)" }}>$ </span>
         {command}
       </div>
+    </div>
+  );
+}
+
+/**
+ * v2.4.0 P5 (#30): pill rendered next to a check label or command
+ * label that came from a fired conditional group. The conditional ids
+ * are concatenated with `+` so multiple-rule contributions read at a
+ * glance ("+php-detected +wordpress-detected"). Hover surfaces the
+ * raw ids via the title attribute — operators inspecting "why is this
+ * here?" see exactly which rules fired.
+ *
+ * `muted` (orphan state) dims the pill so it reads as a "this used to
+ * apply" hint rather than active context.
+ */
+function ProvenanceBadge({
+  ids,
+  muted = false,
+}: {
+  ids: ReadonlyArray<string>;
+  muted?: boolean;
+}) {
+  const text = ids.map((id) => `+${id}`).join(" ");
+  return (
+    <span
+      className="mono"
+      title={`Triggered by conditional${ids.length === 1 ? "" : "s"}: ${ids.join(", ")}`}
+      style={{
+        fontSize: 9.5,
+        letterSpacing: "0.04em",
+        padding: "1px 6px",
+        borderRadius: 999,
+        background: muted ? "transparent" : "var(--accent-bg)",
+        border: `1px solid ${muted ? "var(--border)" : "var(--accent-border)"}`,
+        color: muted ? "var(--fg-faint)" : "var(--accent)",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {text}
+    </span>
+  );
+}
+
+/**
+ * v2.4.0 P5 (#30): subtle separator that introduces the conditional /
+ * orphan groups within the checklist section. Keeps the baseline list
+ * scannable while still grouping context-specific rows below.
+ */
+function ConditionalGroupHeader({
+  label,
+  muted = false,
+}: {
+  label: string;
+  muted?: boolean;
+}) {
+  return (
+    <div
+      className="mono uppercase tracking-[0.06em]"
+      style={{
+        fontSize: 9.5,
+        marginTop: 6,
+        paddingTop: 6,
+        paddingLeft: 4,
+        borderTop: "1px dashed var(--border-subtle)",
+        color: muted ? "var(--fg-faint)" : "var(--fg-subtle)",
+      }}
+    >
+      {label}
+    </div>
+  );
+}
+
+/**
+ * v2.4.0 P5 (#30): wraps a ChecklistItem with a provenance badge to
+ * its right. Orphan rows dim the label color via the badge's `muted`
+ * flag and an opacity wrapper so the operator's prior toggle state is
+ * still visible but visually deprioritised.
+ */
+function ConditionalChecklistRow({
+  engagementId,
+  portId,
+  check,
+  initialChecked,
+  orphan = false,
+}: {
+  engagementId: number;
+  portId: number;
+  check: { key: string; label: string; conditionalId?: string };
+  initialChecked: boolean;
+  orphan?: boolean;
+}) {
+  return (
+    <div
+      className="flex items-center gap-2"
+      style={{ opacity: orphan ? 0.65 : 1 }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <ChecklistItem
+          engagementId={engagementId}
+          portId={portId}
+          checkKey={check.key}
+          initialChecked={initialChecked}
+          label={check.label}
+        />
+      </div>
+      {check.conditionalId && (
+        <ProvenanceBadge ids={[check.conditionalId]} muted={orphan} />
+      )}
     </div>
   );
 }

--- a/src/lib/kb/__tests__/resolve.test.ts
+++ b/src/lib/kb/__tests__/resolve.test.ts
@@ -312,7 +312,9 @@ describe("applyConditionals (v2.4.0 P4 #29)", () => {
     const out = applyConditionals(entry, ctx);
     expect(out.active.map((a) => a.id)).toEqual(["php-detected"]);
     expect(out.inactive.map((i) => i.id)).toEqual(["wp-detected"]);
-    expect(out.inactive[0].checkKeys).toEqual(["wp-xmlrpc"]);
+    expect(out.inactive[0].adds_checks).toEqual([
+      { key: "wp-xmlrpc", label: "Tested xmlrpc" },
+    ]);
   });
 
   it("baseline checks are not duplicated by a colliding conditional add", () => {

--- a/src/lib/kb/resolve.ts
+++ b/src/lib/kb/resolve.ts
@@ -85,8 +85,14 @@ export interface ResolvedCommand {
 export interface InactiveConditional {
   /** Conditional `id` from the KB entry. */
   id: string;
-  /** `adds_checks[].key` values from this conditional, for orphan detection. */
-  checkKeys: string[];
+  /**
+   * `adds_checks` declared by this conditional. The page joins on
+   * `check_states.check_key` to detect orphans — operator toggled a
+   * check under a conditional that has since stopped matching. Labels
+   * are carried through so the orphan UI can render the original
+   * human-readable text instead of falling back to the bare key.
+   */
+  adds_checks: ReadonlyArray<{ key: string; label: string }>;
 }
 
 export interface ResolvedEntry {
@@ -302,7 +308,10 @@ export function applyConditionals(
     } else {
       inactive.push({
         id: cond.id,
-        checkKeys: cond.adds_checks.map((c) => c.key),
+        adds_checks: cond.adds_checks.map((c) => ({
+          key: c.key,
+          label: c.label,
+        })),
       });
     }
   }


### PR DESCRIPTION
Final phase of #14 (\`v2.4.0\` milestone). Closes #30.

**Browser-tested live** with a hand-crafted conditional on \`21-ftp.yaml\` against the sample engagement (vsftpd 3.0.3): pill rendered green next to \"Banner grab\", CONTEXT-SPECIFIC group surfaced with the new check, light mode confirmed legible. Test KB change reverted before commit.

## Summary

- **PortDetailPane** — kbCommands gains optional \`conditionalIds[]\`, kbChecks gains \`source: baseline | conditional | orphan\` + \`conditionalId\`.
- **Three new helpers**: \`ProvenanceBadge\` (the +id pill, supports a muted orphan variant), \`ConditionalGroupHeader\` (subtle separator for the bottom-of-list groups), \`ConditionalChecklistRow\` (wraps ChecklistItem with a trailing badge + opacity wrapper for orphans).
- **Engagement page** maps resolver output to the new shapes and reconciles orphans against \`check_states\` — only surfaces orphans the operator already touched, so a brand-new never-toggled check from a no-longer-firing conditional just disappears (no clutter).
- **Resolver** \`InactiveConditional.checkKeys\` → \`adds_checks: { key, label }[]\` so the orphan UI can render the original human label.

## Visual sanity (live test)

Dark — checklist row + command label both pick up the green \`+vsftpd-detected\` pill, separator reads \"CONTEXT-SPECIFIC\". Light — pill switches to the AA-tuned darker green from #3's light tokens, separator reads as a dashed border under \"CONTEXT-SPECIFIC\". Orphan state inherits a 65% opacity wrapper.

## Test plan
- [x] \`npm run test\` — 528 pass.
- [x] \`npm run typecheck\` clean.
- [x] ESLint clean.
- [x] Browser smoke (light + dark, conditional firing, command modification visible).

## What's next

v2.4.0 milestone is now feature-complete:
- ✓ #26 P1 KB schema + lint
- ✓ #27 P2 nmap fingerprint extractor
- ✓ #28 P3 AutoRecon fingerprint extractor
- ✓ #29 P4 conditional resolver
- ✓ #30 P5 UI provenance badges (this PR)

After merge: bump version 2.3.0 → 2.4.0, CHANGELOG entry, tag release.