### PR TITLE
chore: release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 All notable changes to recon-deck. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] — 2026-05-07
+
+Minor. **Context-aware checklists** ship — the headline feature of #14.
+The KB now lets each service entry declare conditional groups gated on
+fingerprints extracted from nmap and AutoRecon output, and the engagement
+page automatically surfaces those groups when the matching signal is
+present. Operators get extra checks + tweaked commands without a single
+manual configuration.
+
+### Added
+
+- **KB conditional groups.** Each service entry can declare an optional
+  `conditional[]` array. Each entry has an `id`, a `when` predicate
+  (`nmap_script_contains`, `nmap_version_matches` with semver ops + ranges,
+  `autorecon_finding`, `port_field_equals`, plus `anyOf` / `allOf` / `not`
+  combinators), `adds_checks[]`, and `modifies_commands` keyed by command
+  `id`. The schema is purely additive — every existing entry parses
+  unchanged. (#26)
+- **Lint rules** for the new shape: duplicate conditional ids, dangling
+  `modifies_commands` references, baseline-vs-conditional check key
+  collisions, plus the existing placeholder allowlist + denylist applied
+  to modified templates. Build-time errors point at the file + rule. (#26)
+- **Per-port fingerprint store.** New `port_fingerprints` table
+  (migration 0021): `(port_id, source: nmap | autorecon, type: tech | cves
+  | banners, value)`. Idempotent rescans via `UNIQUE` on the composite. (#27)
+- **nmap fingerprint extractor.** Pure-function heuristic distills tech
+  tags (apache, nginx, php, wordpress, openssh, vsftpd, mysql, …), CVE
+  references (`CVE-YYYY-NNNNN` regex), and banners from
+  `(product, version, extrainfo, NSE script bodies)`. Wired into both
+  `createFromScan` and `applyRescan` import paths. (#27)
+- **AutoRecon fingerprint extractor.** Same shape, different source —
+  pulls signals from whatweb / feroxbuster / nikto / dirb output. Adds a
+  discovery-tool extension heuristic that tags `php` / `asp.net` / `java`
+  when the per-tag URL extension count clears a threshold. Persisted with
+  `source: autorecon` so a fresh nmap rescan doesn't blow them away. (#28)
+- **Conditional resolver.** Pure functions that evaluate the `when` DSL
+  against a `ResolveContext` built from the port row, NSE scripts, and
+  fingerprint rows. Merges baseline + matched conditionals into a
+  `ResolvedEntry` carrying provenance metadata. Conflict policy locked:
+  appends in declaration order, replaces last-wins. Returns an
+  `inactive[]` payload so the page can detect orphaned check states. (#29)
+- **UI provenance badges.** Conditional-driven checks render below a
+  `CONTEXT-SPECIFIC` separator with a `+conditional-id` pill. Modified
+  commands carry the same pill next to their label. Orphan rows
+  (operator-toggled checks whose conditional has stopped matching after
+  a re-import) render at 65% opacity under their own
+  `Orphaned · signal no longer present` separator — the operator's
+  prior work is preserved instead of silently disappearing. Tested in
+  light + dark. (#30)
+
 ## [2.3.0] — 2026-05-07
 
 Minor. Light theme arrives, plus three operator-facing fixes: smarter

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 Offline. Self-hosted. Every engagement export-ready as Markdown.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.3.0-blue)](CHANGELOG.md)
-[![Schema](https://img.shields.io/badge/schema-0020-orange)](src/lib/db/migrations/)
+[![Version](https://img.shields.io/badge/version-2.4.0-blue)](CHANGELOG.md)
+[![Schema](https://img.shields.io/badge/schema-0021-orange)](src/lib/db/migrations/)
 [![GHCR](https://img.shields.io/badge/ghcr.io-kocaemre%2Frecon--deck-2496ED?logo=docker&logoColor=white)](https://github.com/kocaemre/recon-deck/pkgs/container/recon-deck)
 [![Next.js](https://img.shields.io/badge/Next.js-15.5-black?logo=next.js)](https://nextjs.org)
 [![Offline-first](https://img.shields.io/badge/network-offline_by_default-success)](SECURITY.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recon-deck",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "private": true,
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Closes the v2.4.0 milestone — context-aware checklists ship end-to-end across KB schema (#26), nmap fingerprints (#27), AutoRecon fingerprints (#28), conditional resolver (#29), and UI provenance badges (#30).

## Summary
- Version: 2.3.0 → 2.4.0
- Schema badge: 0020 → 0021 (port_fingerprints)
- CHANGELOG entry covering all five #14 phases

## Test plan
- [x] \`npm run test\` — 528 pass
- [x] \`npm run typecheck\` clean
- [x] ESLint clean
- [x] \`npm run build\` succeeds locally

After merge: tag \`v2.4.0\` to trigger the multi-arch release workflow.