### PR TITLE
fix(security): v2.4.1 — KB user-dir hardening + render-time href guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to recon-deck. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] — 2026-06-16
+
+Patch. **Security hardening** of the operator-configurable KB directory and
+the port-detail external links. No schema change, no feature change — drop-in
+upgrade. Found via a SAST sweep and confirmed on a live deployment.
+
+### Security
+
+- **KB user directory: symlink escape + missing server-side validation.**
+  The `kb_user_dir` setting was persisted (via the onboarding server actions)
+  with no server-side path validation — the `isAbsolute` check existed only as
+  a client-side UX chip. The KB loader then enumerated that directory and read
+  every `*.yaml` entry. A `*.yaml` **symlink** pointing at an arbitrary file
+  (e.g. `/etc/passwd`) was followed and the target opened/read into memory
+  before schema validation rejected it. Confidentiality impact was bounded
+  (flat `*.yaml`-only, strict `KbEntrySchema`, parse failures never returned
+  over HTTP), but the file was still read. Fixes:
+  - `app/welcome/_actions.ts` now enforces `path.isAbsolute` server-side for
+    all operator path fields (`kb_user_dir`, `local_export_dir`,
+    `wordlist_base`) — never trust the client to have run the check.
+  - `src/lib/kb/loader.ts` skips symlinked entries (`lstat`) and verifies each
+    resolved file path stays within the KB dir before reading — a symlinked
+    `*.yaml` is now never opened.
+- **Port-detail external links: render-time scheme guard (defense in depth).**
+  `PortDetailPane` rendered KB `known_vulns[].link` / `resources[].url` and
+  exploit-db URLs into `<a href>` trusting only ingest-time Zod `httpUrl`
+  validation. Render now passes every dynamic href through `isAllowedUrl`
+  (mirroring `ResourceLink`), so a `javascript:`/`data:` URL can never reach an
+  anchor even if a future ingest path skips the schema check.
+
 ## [2.4.0] — 2026-05-07
 
 Minor. **Context-aware checklists** ship — the headline feature of #14.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Offline. Self-hosted. Every engagement export-ready as Markdown.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.4.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-2.4.1-blue)](CHANGELOG.md)
 [![Schema](https://img.shields.io/badge/schema-0021-orange)](src/lib/db/migrations/)
 [![GHCR](https://img.shields.io/badge/ghcr.io-kocaemre%2Frecon--deck-2496ED?logo=docker&logoColor=white)](https://github.com/kocaemre/recon-deck/pkgs/container/recon-deck)
 [![Next.js](https://img.shields.io/badge/Next.js-15.5-black?logo=next.js)](https://nextjs.org)

--- a/app/welcome/_actions.ts
+++ b/app/welcome/_actions.ts
@@ -33,6 +33,25 @@ function sanitize(value: string): string | null {
 }
 
 /**
+ * Server-side path validation for the operator-supplied directories
+ * (SEC: was client-only via `validatePath`, the on-blur ✓/✗ chip).
+ *
+ * The persisted `kb_user_dir` is later enumerated and read by the KB
+ * loader, so the write path must enforce the same `isAbsolute` invariant
+ * the UI shows — never trust the client to have run the check. Relative
+ * inputs (resolved against cwd) and other non-absolute strings are
+ * rejected here so they can never reach the loader.
+ */
+function sanitizePath(value: string, label: string): string | null {
+  const trimmed = sanitize(value);
+  if (trimmed === null) return null;
+  if (!path.isAbsolute(trimmed)) {
+    throw new Error(`${label} must be an absolute path.`);
+  }
+  return trimmed;
+}
+
+/**
  * Path validation backing the on-blur ✓/✗ chip on Step 3. Only checks
  * `R_OK` so a read-only mount (or an SecLists symlinked from another
  * volume) still passes. Empty input → `empty`.
@@ -58,9 +77,9 @@ async function persist(
   payload: OnboardingPayload,
 ): Promise<ActionResult> {
   try {
-    const localExportDir = sanitize(payload.localExportDir);
-    const kbUserDir = sanitize(payload.kbUserDir);
-    const wordlistBase = sanitize(payload.wordlistBase);
+    const localExportDir = sanitizePath(payload.localExportDir, "Export directory");
+    const kbUserDir = sanitizePath(payload.kbUserDir, "KB directory");
+    const wordlistBase = sanitizePath(payload.wordlistBase, "Wordlist base");
 
     markOnboarded(db, {
       local_export_dir: localExportDir,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recon-deck",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/src/components/PortDetailPane.tsx
+++ b/src/components/PortDetailPane.tsx
@@ -24,6 +24,7 @@ import { ExternalLink, Plus, Search as SearchIcon } from "lucide-react";
 import type { ScriptElem, ScriptTable } from "@/lib/parser/types";
 import type { PortEvidence } from "@/lib/db/schema";
 import { useUIStore } from "@/lib/store";
+import { isAllowedUrl } from "@/lib/security/validate-url";
 
 type FindingSeverity = "info" | "low" | "medium" | "high" | "critical";
 
@@ -220,7 +221,7 @@ export function PortDetailPane({
                       {v.note}
                     </span>
                     <a
-                      href={v.link}
+                      href={safeHref(v.link)}
                       target="_blank"
                       rel="noreferrer"
                       style={{
@@ -491,7 +492,7 @@ export function PortDetailPane({
               {kbResources.map((r, i) => (
                 <a
                   key={i}
-                  href={r.url}
+                  href={safeHref(r.url)}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="flex items-center gap-1.5"
@@ -733,6 +734,17 @@ function safeHostname(url: string): string {
   } catch {
     return "";
   }
+}
+
+/**
+ * Render-time scheme guard (SEC, defense in depth). KB links are scheme-gated
+ * at ingest by the Zod `httpUrl` validator, but render must not trust ingest:
+ * if any future ingest path skips that check, a `javascript:` URL must still
+ * never reach an `<a href>`. Returns `undefined` for disallowed schemes so the
+ * anchor renders without an href (no navigable link), mirroring ResourceLink.
+ */
+function safeHref(url: string): string | undefined {
+  return isAllowedUrl(url) ? url : undefined;
 }
 
 /**
@@ -1068,7 +1080,7 @@ function ExploitsSection({
                   </span>
                   {h.url && (
                     <a
-                      href={h.url}
+                      href={safeHref(h.url)}
                       target="_blank"
                       rel="noreferrer"
                       style={{
@@ -1155,7 +1167,7 @@ function ExploitsSection({
                     </span>
                     {h.url && (
                       <a
-                        href={h.url}
+                        href={safeHref(h.url)}
                         target="_blank"
                         rel="noreferrer"
                         style={{

--- a/src/lib/kb/loader.ts
+++ b/src/lib/kb/loader.ts
@@ -57,12 +57,28 @@ export function loadKnowledgeBase(opts: {
   }
 
   // 3. User entries — soft failure per file (T-06), missing dir non-fatal (T-05)
+  //
+  // Defense in depth (SEC): the user dir is operator-configurable, so never
+  // follow a symlink out of it. A symlink named `*.yaml` that points at an
+  // arbitrary file (e.g. `/etc/passwd`) would otherwise be opened and read
+  // into memory before schema validation rejects it. We skip symlinked
+  // entries and any entry whose resolved path escapes the dir.
   const user: KbEntry[] = [];
   if (opts.userDir && fs.existsSync(opts.userDir)) {
+    const baseReal = fs.realpathSync(opts.userDir);
     for (const file of fs.readdirSync(opts.userDir)) {
       if (!file.endsWith(".yaml")) continue;
-      const fp = path.join(opts.userDir, file);
+      const fp = path.join(baseReal, file);
       try {
+        if (fs.lstatSync(fp).isSymbolicLink()) {
+          console.warn(`[kb] skipping symlinked user file ${fp}`);
+          continue;
+        }
+        const real = fs.realpathSync(fp);
+        if (real !== fp && !real.startsWith(baseReal + path.sep)) {
+          console.warn(`[kb] skipping out-of-dir user file ${fp}`);
+          continue;
+        }
         user.push(KbEntrySchema.parse(readYamlFile(fp)));
       } catch (err) {
         console.warn(`[kb] skipping invalid user file ${fp}: ${String(err)}`);


### PR DESCRIPTION
## Özet

v2.4.1 (patch) — SAST taramasında bulunup **canlı deploy üzerinde doğrulanan** 2 LOW-severity güvenlik bulgusunun düzeltmesi. Şema değişikliği yok, davranış değişikliği yok (meşru KB akışı), drop-in upgrade.

## Bulgular & düzeltmeler

### 1. KB user dir — symlink escape + eksik server-side doğrulama (LOW)
`kb_user_dir` onboarding server action'larıyla **server tarafında hiçbir path doğrulaması olmadan** kaydediliyordu (`isAbsolute` yalnızca client UX chip'iydi). KB loader o dizini enumerate edip her `*.yaml`'ı okuyor; `*.yaml` adıyla bir **symlink** (örn. `-> /etc/passwd`) takip edilip hedef dosya şema reddinden **önce açılıp belleğe okunuyordu**. Confidentiality etkisi sınırlı (düz `*.yaml`, strict `KbEntrySchema`, parse hataları HTTP'ye dönmüyor) ama dosya yine de okunuyordu.

- `app/welcome/_actions.ts`: tüm operatör path alanları için server-side `path.isAbsolute` zorunlu.
- `src/lib/kb/loader.ts`: symlink'leri `lstat` ile atla + okumadan önce çözülen path'in dizin içinde kaldığını doğrula.

### 2. Port-detail dış linkler — render-time scheme guard (LOW, defense-in-depth)
`PortDetailPane` KB `known_vulns[].link` / `resources[].url` ve exploit-db URL'lerini yalnızca ingest-time Zod `httpUrl` doğrulamasına güvenerek `<a href>`'e basıyordu. Render artık her dinamik href'i `isAllowedUrl`'den geçiriyor (`ResourceLink` ile aynı), böylece ileride bir ingest yolu şemayı atlasa bile `javascript:`/`data:` URL bir anchor'a ulaşamaz.

## Canlı doğrulama

Ubuntu 24.04 sunucuda Docker ile kuruldu:

- **Önce (v2.4.0):** `[kb] skipping invalid user file /tmp/evilkb/passwd.yaml` → symlink takip edildi, `/etc/passwd` açılıp okundu.
- **Sonra (fixed):** `[kb] skipping symlinked user file /tmp/evilkb/passwd.yaml` → `/etc/passwd` hiç açılmadı. Meşru KB girdisi normal merge oldu.
- App `/` & `/api/health` → 200, healthy.

## Test

- typecheck: temiz
- vitest: 526/528 geçti. 2 fail = `probe.test.ts` (root altında `0o444` baypas edildiği için writability probe throw etmiyor) — **pristine v2.4.0'da da fail eden ortam artefaktı**, bu PR'dan kaynaklı değil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)