### PR TITLE
chore(release): beta release channel (pre-release → :beta, install.sh --beta)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,17 +42,22 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
-          # Semver-driven tags from the git tag. Given v1.2.3:
-          #   → ghcr.io/kocaemre/recon-deck:1.2.3
-          #   → ghcr.io/kocaemre/recon-deck:1.2
-          #   → ghcr.io/kocaemre/recon-deck:1
-          #   → ghcr.io/kocaemre/recon-deck:latest
+          # `latest=auto` only attaches :latest to a STABLE semver tag — a
+          # pre-release tag (v1.2.3-beta.1) never moves :latest. This is what
+          # keeps the beta channel from clobbering what stable users pull.
+          flavor: |
+            latest=auto
+          # Semver-driven tags from the git tag.
+          #   Stable  v1.2.3        → :1.2.3  :1.2  :1  :latest
+          #   Beta    v1.2.3-beta.1 → :1.2.3-beta.1  :beta   (NO :latest, NO :1.2/:1)
+          # The moving short tags (:1.2, :1) and :latest are reserved for stable
+          # so a beta can never shadow a stable image at a coarse tag.
           # For v0.x.x: major-version tag is disabled to avoid an unstable "0".
           tags: |
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            type=raw,value=latest
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-') }}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') && !contains(github.ref, '-') }}
+            type=raw,value=beta,enable=${{ contains(github.ref, '-') }}
 
       # ─── Build WITHOUT push first, load locally, smoke test ───
       - name: Build (amd64) for smoke test
@@ -103,3 +108,8 @@ jobs:
           name: ${{ github.ref_name }}
           generate_release_notes: true
           fail_on_unmatched_files: false
+          # Tags with a pre-release suffix (v2.5.0-beta.1) are published as
+          # GitHub pre-releases. GitHub's /releases/latest endpoint excludes
+          # pre-releases, so the in-app update toast never nudges stable users
+          # toward a beta — only opted-in beta clients see them.
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to recon-deck. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Beta release channel.** New features now ship to a pre-release channel
+  before promotion to stable, so `main`/stable stays clean:
+  - The release workflow publishes pre-release tags (`vX.Y.Z-beta.N`) to a
+    moving `:beta` Docker tag plus the pinned `:X.Y.Z-beta.N`, and marks the
+    GitHub release as a pre-release. Stable's `:latest` / `:X.Y` / `:X` tags
+    are never moved by a beta build.
+  - `install.sh --beta` (and `--stable`) selects the channel; default stays
+    stable.
+  - The in-app update check honors `RECON_UPDATE_CHANNEL=beta` to track the
+    newest pre-release. The default stable check uses GitHub's
+    `/releases/latest`, which excludes pre-releases, so stable installs are
+    never nudged toward a beta. Version comparison is now pre-release aware.
+
 ## [2.4.1] — 2026-06-16
 
 Patch. **Security hardening** of the operator-configurable KB directory and

--- a/README.md
+++ b/README.md
@@ -170,6 +170,20 @@ docker run -d --name recon-deck -p 127.0.0.1:13337:13337 \
 
 Open <http://localhost:13337>, paste nmap output, see cards. The `-p 127.0.0.1:13337:13337` host-side prefix keeps the app loopback-only — see [Exposing to LAN](#exposing-to-lan) for LAN reachability.
 
+### Beta channel (early builds)
+
+Stable is the default. To try the newest pre-release build (new features land here first; may be unstable):
+
+```bash
+# One-liner
+curl -sSL https://raw.githubusercontent.com/kocaemre/recon-deck/main/install.sh | sh -s -- --beta
+
+# or pull the beta image directly
+docker pull ghcr.io/kocaemre/recon-deck:beta
+```
+
+Image tags: `:latest` and `:X.Y.Z` are stable; `:beta` always points at the newest pre-release, and each beta is also pinned at `:X.Y.Z-beta.N`. Switch back to stable any time with `--stable` (or pull `:latest`). To have the in-app update toast track betas, set `RECON_UPDATE_CHANNEL=beta` (otherwise it only ever surfaces stable releases).
+
 ---
 
 ## What it is / What it is NOT

--- a/app/api/update-check/route.ts
+++ b/app/api/update-check/route.ts
@@ -5,9 +5,11 @@
  * short-circuits with `{ enabled: false }` so the client never makes the
  * outbound fetch — keeping recon-deck's "offline by default" promise.
  *
- * When ON, fetches the public latest-release endpoint and compares against
- * the bundled package.json version using a naive semver compare (good
- * enough — recon-deck tags are always X.Y.Z without pre-release suffixes).
+ * When ON, fetches the public release endpoint and compares against the
+ * bundled package.json version with a semver-aware compare that understands
+ * pre-release suffixes. The stable channel uses /releases/latest (GitHub
+ * excludes pre-releases there); set RECON_UPDATE_CHANNEL=beta to track the
+ * newest pre-release instead.
  *
  * Process-level cache: only successful results are memoized for 1 hour.
  * Failures (rate limit, 5xx, network) are never cached, so the next call
@@ -40,13 +42,50 @@ type SuccessPayload = Extract<UpdateInfo, { enabled: true; ok: true }>;
 const CACHE_TTL_MS = 60 * 60 * 1000;
 let cache: { fetchedAt: number; payload: SuccessPayload } | null = null;
 
+function parseVersion(v: string): { nums: number[]; pre: string | null } {
+  const [core, pre = null] = v.replace(/^v/, "").split("-", 2) as [
+    string,
+    string?,
+  ];
+  return { nums: core.split(".").map((n) => Number(n) || 0), pre };
+}
+
+/**
+ * SemVer-aware compare. Core X.Y.Z compared numerically; a build WITH a
+ * pre-release suffix (2.5.0-beta.1) ranks BELOW the same core without one
+ * (2.5.0), and two pre-releases compare by dot-separated identifiers
+ * (numeric < alphanumeric, numbers compared by value). This lets the beta
+ * channel correctly detect beta.1 → beta.2 → final, while stable-vs-stable
+ * (no suffix) behaves exactly as before.
+ */
 function compareSemver(a: string, b: string): number {
-  const pa = a.replace(/^v/, "").split(".").map((n) => Number(n) || 0);
-  const pb = b.replace(/^v/, "").split(".").map((n) => Number(n) || 0);
+  const va = parseVersion(a);
+  const vb = parseVersion(b);
   for (let i = 0; i < 3; i++) {
-    const da = pa[i] ?? 0;
-    const dbn = pb[i] ?? 0;
-    if (da !== dbn) return da - dbn;
+    const d = (va.nums[i] ?? 0) - (vb.nums[i] ?? 0);
+    if (d !== 0) return d;
+  }
+  if (va.pre === null && vb.pre === null) return 0;
+  if (va.pre === null) return 1; // stable > pre-release of same core
+  if (vb.pre === null) return -1;
+  const pa = va.pre.split(".");
+  const pb = vb.pre.split(".");
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const ia = pa[i];
+    const ib = pb[i];
+    if (ia === undefined) return -1;
+    if (ib === undefined) return 1;
+    const na = Number(ia);
+    const nb = Number(ib);
+    const aNum = ia !== "" && !Number.isNaN(na);
+    const bNum = ib !== "" && !Number.isNaN(nb);
+    if (aNum && bNum) {
+      if (na !== nb) return na - nb;
+    } else if (aNum !== bNum) {
+      return aNum ? -1 : 1; // numeric identifiers rank below alphanumeric
+    } else if (ia !== ib) {
+      return ia < ib ? -1 : 1;
+    }
   }
   return 0;
 }
@@ -67,14 +106,20 @@ export async function GET(req: Request) {
     return NextResponse.json(cache.payload);
   }
 
+  // Beta channel opt-in (env-gated, server-only). On the stable channel we
+  // hit /releases/latest, which GitHub guarantees excludes pre-releases — so
+  // stable installs are never nudged toward a beta. On the beta channel we
+  // list recent releases (pre-releases included) and take the newest.
+  const betaChannel = process.env.RECON_UPDATE_CHANNEL === "beta";
+  const endpoint = betaChannel
+    ? "https://api.github.com/repos/kocaemre/recon-deck/releases?per_page=10"
+    : "https://api.github.com/repos/kocaemre/recon-deck/releases/latest";
+
   try {
-    const res = await fetch(
-      "https://api.github.com/repos/kocaemre/recon-deck/releases/latest",
-      {
-        headers: { Accept: "application/vnd.github+json" },
-        cache: "no-store",
-      },
-    );
+    const res = await fetch(endpoint, {
+      headers: { Accept: "application/vnd.github+json" },
+      cache: "no-store",
+    });
     if (!res.ok) {
       const remaining = res.headers.get("x-ratelimit-remaining");
       const isRateLimited = res.status === 403 && remaining === "0";
@@ -85,8 +130,13 @@ export async function GET(req: Request) {
         current: pkg.version,
       });
     }
-    const json = (await res.json()) as { tag_name?: string; html_url?: string };
-    const latestRaw = json.tag_name ?? "";
+    type Release = { tag_name?: string; html_url?: string; draft?: boolean };
+    const body = (await res.json()) as Release | Release[];
+    // Stable endpoint returns one release; the beta list returns newest-first.
+    const release = Array.isArray(body)
+      ? body.find((r) => !r.draft)
+      : body;
+    const latestRaw = release?.tag_name ?? "";
     const latest = latestRaw.replace(/^v/, "");
     if (!latest) {
       return NextResponse.json<UpdateInfo>({
@@ -103,7 +153,7 @@ export async function GET(req: Request) {
       current: pkg.version,
       latest,
       hasUpdate,
-      url: json.html_url,
+      url: release?.html_url,
     };
     cache = { fetchedAt: Date.now(), payload };
     return NextResponse.json(payload);

--- a/install.sh
+++ b/install.sh
@@ -3,11 +3,16 @@
 # recon-deck — one-liner Docker installer.
 #
 # Usage:
-#   curl -sSL https://raw.githubusercontent.com/kocaemre/recon-deck/main/install.sh | sh
+#   Stable: curl -sSL https://raw.githubusercontent.com/kocaemre/recon-deck/main/install.sh | sh
+#   Beta:   curl -sSL https://raw.githubusercontent.com/kocaemre/recon-deck/main/install.sh | sh -s -- --beta
+#
+# Channels:
+#   (default)  pulls :latest — the stable release.
+#   --beta     pulls :beta   — the newest pre-release build (may be unstable).
 #
 # What it does:
 #   1. Verifies docker + docker daemon are reachable.
-#   2. Pulls the latest ghcr.io/kocaemre/recon-deck image.
+#   2. Pulls the selected ghcr.io/kocaemre/recon-deck image (stable or beta).
 #   3. Creates persistent named volumes for the SQLite DB + user KB.
 #   4. Runs the container detached on 127.0.0.1:13337 (loopback only — solo
 #      pentest tool, never exposed to LAN by default). Port 13337 was picked
@@ -18,7 +23,24 @@
 
 set -euo pipefail
 
-IMAGE="ghcr.io/kocaemre/recon-deck:latest"
+# Channel selection — default stable (:latest), opt into pre-releases with --beta.
+CHANNEL_TAG="latest"
+for arg in "$@"; do
+  case "$arg" in
+    --beta|--channel=beta)     CHANNEL_TAG="beta" ;;
+    --stable|--channel=stable) CHANNEL_TAG="latest" ;;
+    -h|--help)
+      printf 'Usage: install.sh [--beta]\n  --beta   install the newest pre-release build (default: stable)\n'
+      exit 0
+      ;;
+    *)
+      printf 'Unknown option: %s (use --beta or --stable)\n' "$arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+IMAGE="ghcr.io/kocaemre/recon-deck:${CHANNEL_TAG}"
 CONTAINER_NAME="recon-deck"
 PORT="13337"
 URL="http://localhost:${PORT}"


### PR DESCRIPTION
## Sprint 0 — Beta release channel

Foundation so new work ships to a **pre-release channel** before promotion to stable; `main`/stable stays clean. No app feature change, no DB migration.

### Changes
- **`.github/workflows/release.yml`** — `flavor: latest=auto` + removed the unconditional `:latest` raw tag. Result:
  - Stable `vX.Y.Z` → `:X.Y.Z` `:X.Y` `:X` `:latest`
  - Beta `vX.Y.Z-beta.N` → `:X.Y.Z-beta.N` + moving `:beta` (**never** `:latest`/`:X.Y`/`:X`)
  - GitHub Release marked `prerelease: true` for `-` tags.
- **`install.sh`** — `--beta` / `--stable` channel flag (default stable). `... | sh -s -- --beta`.
- **`app/api/update-check/route.ts`** — `RECON_UPDATE_CHANNEL=beta` tracks the newest pre-release via the releases list; stable keeps `/releases/latest` (GitHub excludes pre-releases there, so stable users are never nudged to a beta). Version compare is now pre-release aware (`2.5.0-beta.1 < 2.5.0-beta.2 < 2.5.0`).
- **README** beta-channel section + **CHANGELOG** Unreleased entry.

### Why this design
GitHub's `/releases/latest` already excludes pre-releases and `latest=auto` already skips `:latest` for pre-release semver — so the "stable users never accidentally get a beta" guarantee mostly falls out of the platform. The offline-first promise is untouched (update-check stays opt-in/env-gated).

### Validation
- `bash -n install.sh` ✅, `release.yml` YAML parses ✅, `tsc --noEmit` ✅
- No direct tests for the touched code; CI runs the full suite.

### Follow-up
After merge: create `develop` branch from `main`; future feature work (AI co-pilot, Exam Mode, etc.) flows develop → `vX.Y.Z-beta.N` → stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)