### PR TITLE
feat(ai): AI co-pilot config + Exam Mode foundation (Sprint 1a)

### DIFF
--- a/app/api/ai/status/route.ts
+++ b/app/api/ai/status/route.ts
@@ -1,0 +1,18 @@
+/**
+ * GET /api/ai/status — client-safe AI assistant state (v2.5.0).
+ *
+ * Returns whether the AI co-pilot is usable right now and why not, without
+ * ever exposing the API key or endpoint. The UI uses this to show/hide AI
+ * affordances and to render the Exam Mode badge. Mirrors the opt-in,
+ * server-resolved pattern of /api/update-check.
+ */
+
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { publicAiStatus } from "@/lib/ai/config";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json(publicAiStatus(db));
+}

--- a/src/lib/ai/__tests__/config.test.ts
+++ b/src/lib/ai/__tests__/config.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, afterEach, describe, expect, it } from "vitest";
+import { createTestDb } from "../../../../tests/helpers/db.js";
+import { setAppState } from "../../db/app-state-repo.js";
+import {
+  effectiveAiConfig,
+  publicAiStatus,
+  normalizeProvider,
+  AI_PROVIDERS,
+} from "../config.js";
+
+const AI_ENV = [
+  "RECON_AI_ENABLED",
+  "RECON_AI_BASE_URL",
+  "RECON_AI_MODEL",
+  "RECON_AI_API_KEY",
+  "RECON_EXAM_MODE",
+];
+
+describe("ai/config (v2.5.0 AI co-pilot resolver)", () => {
+  let db: ReturnType<typeof createTestDb>;
+
+  beforeEach(() => {
+    db = createTestDb();
+    for (const k of AI_ENV) delete process.env[k];
+  });
+  afterEach(() => {
+    for (const k of AI_ENV) delete process.env[k];
+  });
+
+  it("fresh install: disabled, local provider default, no key", () => {
+    const c = effectiveAiConfig(db);
+    expect(c.enabled).toBe(false);
+    expect(c.reason).toBe("disabled");
+    expect(c.examMode).toBe(false);
+    expect(c.provider).toBe("ollama");
+    expect(c.cloud).toBe(false);
+    expect(c.baseUrl).toBe(AI_PROVIDERS.ollama.defaultBaseUrl);
+    expect(c.model).toBe(AI_PROVIDERS.ollama.defaultModel);
+    expect(c.hasKey).toBe(false);
+  });
+
+  it("enabling a local provider needs no key", () => {
+    setAppState(db, { ai_enabled: true });
+    const c = effectiveAiConfig(db);
+    expect(c.enabled).toBe(true);
+    expect(c.reason).toBeNull();
+  });
+
+  it("exam mode is a hard override even when AI is enabled", () => {
+    setAppState(db, { ai_enabled: true, exam_mode: true });
+    const c = effectiveAiConfig(db);
+    expect(c.enabled).toBe(false);
+    expect(c.reason).toBe("exam_mode");
+    expect(c.examMode).toBe(true);
+  });
+
+  it("cloud provider without a key is disabled (missing_key)", () => {
+    setAppState(db, { ai_enabled: true, ai_provider: "openai" });
+    const c = effectiveAiConfig(db);
+    expect(c.enabled).toBe(false);
+    expect(c.reason).toBe("missing_key");
+    expect(c.cloud).toBe(true);
+    expect(c.baseUrl).toBe(AI_PROVIDERS.openai.defaultBaseUrl);
+    expect(c.model).toBe(AI_PROVIDERS.openai.defaultModel);
+  });
+
+  it("cloud provider with a key is enabled", () => {
+    setAppState(db, {
+      ai_enabled: true,
+      ai_provider: "openrouter",
+      ai_api_key: "sk-test-123",
+    });
+    const c = effectiveAiConfig(db);
+    expect(c.enabled).toBe(true);
+    expect(c.reason).toBeNull();
+    expect(c.hasKey).toBe(true);
+    expect(c.apiKey).toBe("sk-test-123");
+  });
+
+  it("explicit base URL and model override the provider preset", () => {
+    setAppState(db, {
+      ai_enabled: true,
+      ai_provider: "ollama",
+      ai_base_url: "http://127.0.0.1:1234/v1",
+      ai_model: "qwen2.5-coder",
+    });
+    const c = effectiveAiConfig(db);
+    expect(c.baseUrl).toBe("http://127.0.0.1:1234/v1");
+    expect(c.model).toBe("qwen2.5-coder");
+  });
+
+  it("unknown provider value falls back to local ollama", () => {
+    expect(normalizeProvider("totally-bogus")).toBe("ollama");
+    setAppState(db, { ai_enabled: true, ai_provider: "totally-bogus" });
+    expect(effectiveAiConfig(db).provider).toBe("ollama");
+  });
+
+  it("publicAiStatus never exposes the API key", () => {
+    setAppState(db, {
+      ai_enabled: true,
+      ai_provider: "openai",
+      ai_api_key: "sk-secret",
+    });
+    const status = publicAiStatus(db);
+    expect(status.hasKey).toBe(true);
+    expect(JSON.stringify(status)).not.toContain("sk-secret");
+    expect("apiKey" in status).toBe(false);
+    expect("baseUrl" in status).toBe(false);
+  });
+
+  it("env fallback can enable AI and exam mode forces it off", () => {
+    process.env.RECON_AI_ENABLED = "1";
+    expect(effectiveAiConfig(db).enabled).toBe(true);
+    process.env.RECON_EXAM_MODE = "1";
+    const c = effectiveAiConfig(db);
+    expect(c.enabled).toBe(false);
+    expect(c.reason).toBe("exam_mode");
+  });
+});

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -1,0 +1,145 @@
+import "server-only";
+
+/**
+ * AI co-pilot configuration resolver (v2.5.0).
+ *
+ * Turns the raw `app_state` AI fields into the *effective* runtime config the
+ * server proxy route consumes. Three rules live here, deliberately in one
+ * place so every call site agrees:
+ *
+ *   1. **Exam Mode is a hard override.** When on, the assistant is OFF no
+ *      matter what `ai_enabled` says (OSCP-style exams forbid AI). Nothing
+ *      else is touched — internet research / HackTricks stay available.
+ *   2. **Local-first defaults.** An unconfigured provider resolves to Ollama
+ *      on localhost, so enabling AI never silently sends scan data to a cloud.
+ *   3. **Cloud providers need a key.** OpenAI/OpenRouter resolve to disabled
+ *      (reason `missing_key`) until a key is configured.
+ *
+ * The API key never leaves the server: `effectiveAiConfig` returns it for the
+ * proxy route's own outbound call, while `publicAiStatus` strips it (and the
+ * base URL) for anything sent to the client.
+ */
+
+import { effectiveAppState, type Db } from "@/lib/db/app-state-repo";
+
+export type AiProvider = "ollama" | "openai" | "openrouter";
+
+export interface ProviderPreset {
+  label: string;
+  defaultBaseUrl: string;
+  defaultModel: string;
+  /** Cloud providers require an API key; local ones do not. */
+  needsKey: boolean;
+  /** True when requests leave the host (privacy-relevant for scan data). */
+  cloud: boolean;
+}
+
+export const AI_PROVIDERS: Record<AiProvider, ProviderPreset> = {
+  ollama: {
+    label: "Ollama (local)",
+    defaultBaseUrl: "http://127.0.0.1:11434/v1",
+    defaultModel: "llama3.1",
+    needsKey: false,
+    cloud: false,
+  },
+  openai: {
+    label: "OpenAI",
+    defaultBaseUrl: "https://api.openai.com/v1",
+    defaultModel: "gpt-4.1-mini",
+    needsKey: true,
+    cloud: true,
+  },
+  openrouter: {
+    label: "OpenRouter",
+    defaultBaseUrl: "https://openrouter.ai/api/v1",
+    defaultModel: "openai/gpt-4.1-mini",
+    needsKey: true,
+    cloud: true,
+  },
+};
+
+export function isAiProvider(v: string): v is AiProvider {
+  return v === "ollama" || v === "openai" || v === "openrouter";
+}
+
+/** Unknown/garbage provider values fall back to the local default. */
+export function normalizeProvider(raw: string): AiProvider {
+  return isAiProvider(raw) ? raw : "ollama";
+}
+
+export type AiDisabledReason = "exam_mode" | "disabled" | "missing_key" | null;
+
+export interface EffectiveAiConfig {
+  /** Final gate the proxy route checks before making any outbound call. */
+  enabled: boolean;
+  reason: AiDisabledReason;
+  examMode: boolean;
+  provider: AiProvider;
+  /** Resolved endpoint (provider preset unless overridden). */
+  baseUrl: string;
+  model: string;
+  /** Whether a key is configured — NOT the key itself. */
+  hasKey: boolean;
+  cloud: boolean;
+  /** Server-only. Present for the proxy route's outbound call; never serialize. */
+  apiKey: string | null;
+}
+
+export function effectiveAiConfig(db: Db): EffectiveAiConfig {
+  const cfg = effectiveAppState(db);
+  const provider = normalizeProvider(cfg.aiProvider);
+  const preset = AI_PROVIDERS[provider];
+  const baseUrl = cfg.aiBaseUrl ?? preset.defaultBaseUrl;
+  const model = cfg.aiModel ?? preset.defaultModel;
+  const apiKey = cfg.aiApiKey;
+  const hasKey = !!apiKey && apiKey.length > 0;
+
+  let enabled = true;
+  let reason: AiDisabledReason = null;
+  if (cfg.examMode) {
+    enabled = false;
+    reason = "exam_mode";
+  } else if (!cfg.aiEnabled) {
+    enabled = false;
+    reason = "disabled";
+  } else if (preset.needsKey && !hasKey) {
+    enabled = false;
+    reason = "missing_key";
+  }
+
+  return {
+    enabled,
+    reason,
+    examMode: cfg.examMode,
+    provider,
+    baseUrl,
+    model,
+    hasKey,
+    cloud: preset.cloud,
+    apiKey,
+  };
+}
+
+/** Client-safe projection — drops the API key and endpoint. */
+export interface PublicAiStatus {
+  enabled: boolean;
+  reason: AiDisabledReason;
+  examMode: boolean;
+  provider: AiProvider;
+  model: string;
+  hasKey: boolean;
+  cloud: boolean;
+}
+
+export function publicAiStatus(db: Db): PublicAiStatus {
+  const c = effectiveAiConfig(db);
+  return {
+    enabled: c.enabled,
+    reason: c.reason,
+    examMode: c.examMode,
+    provider: c.provider,
+    model: c.model,
+    hasKey: c.hasKey,
+    cloud: c.cloud,
+  };
+}

--- a/src/lib/db/app-state-repo.ts
+++ b/src/lib/db/app-state-repo.ts
@@ -50,6 +50,12 @@ export interface AppStatePatch {
   update_check?: boolean;
   sidebar_collapsed?: boolean;
   theme?: ThemeMode;
+  ai_enabled?: boolean;
+  ai_provider?: string;
+  ai_base_url?: string | null;
+  ai_model?: string | null;
+  ai_api_key?: string | null;
+  exam_mode?: boolean;
 }
 
 /** Partial UPDATE on the singleton; bumps `updated_at` automatically. */
@@ -66,6 +72,12 @@ export function setAppState(db: Db, patch: AppStatePatch): AppState {
   if (patch.sidebar_collapsed !== undefined)
     update.sidebar_collapsed = patch.sidebar_collapsed;
   if (patch.theme !== undefined) update.theme = patch.theme;
+  if (patch.ai_enabled !== undefined) update.ai_enabled = patch.ai_enabled;
+  if (patch.ai_provider !== undefined) update.ai_provider = patch.ai_provider;
+  if (patch.ai_base_url !== undefined) update.ai_base_url = patch.ai_base_url;
+  if (patch.ai_model !== undefined) update.ai_model = patch.ai_model;
+  if (patch.ai_api_key !== undefined) update.ai_api_key = patch.ai_api_key;
+  if (patch.exam_mode !== undefined) update.exam_mode = patch.exam_mode;
 
   db.update(app_state).set(update).where(eq(app_state.id, 1)).run();
   return getAppState(db);
@@ -103,6 +115,15 @@ export interface EffectiveConfig {
   sidebarCollapsed: boolean;
   theme: ThemeMode;
   onboardedAt: string | null;
+  /** Raw AI config (DB value, env fallback). The exam-mode override and
+   *  provider defaults are applied in `src/lib/ai/config.ts`, not here. */
+  aiEnabled: boolean;
+  aiProvider: string;
+  aiBaseUrl: string | null;
+  aiModel: string | null;
+  /** Server-only — never include this in a client payload. */
+  aiApiKey: string | null;
+  examMode: boolean;
 }
 
 function narrowTheme(raw: string): ThemeMode {
@@ -123,5 +144,14 @@ export function effectiveAppState(db: Db): EffectiveConfig {
     sidebarCollapsed: row.sidebar_collapsed,
     theme: narrowTheme(row.theme),
     onboardedAt: row.onboarded_at,
+    // AI: env fallback for the nullable fields + the enable/exam booleans so
+    // an operator can configure via env without onboarding. The DB value wins
+    // whenever it's set.
+    aiEnabled: row.ai_enabled || process.env.RECON_AI_ENABLED === "1",
+    aiProvider: row.ai_provider,
+    aiBaseUrl: row.ai_base_url ?? process.env.RECON_AI_BASE_URL ?? null,
+    aiModel: row.ai_model ?? process.env.RECON_AI_MODEL ?? null,
+    aiApiKey: row.ai_api_key ?? process.env.RECON_AI_API_KEY ?? null,
+    examMode: row.exam_mode || process.env.RECON_EXAM_MODE === "1",
   };
 }

--- a/src/lib/db/migrations/0022_add-ai-config-exam-mode.sql
+++ b/src/lib/db/migrations/0022_add-ai-config-exam-mode.sql
@@ -1,0 +1,24 @@
+-- v2.5.0: optional AI co-pilot config + Exam Mode (both opt-in, default OFF).
+--
+-- AI is disabled by default. When enabled it defaults to a LOCAL provider
+-- (Ollama) so no scan data leaves the host unless the operator explicitly
+-- configures a cloud provider. The API key is stored server-side only and is
+-- never returned to the client (the app-state-repo resolves it; routes read it
+-- behind `server-only`).
+--
+-- Exam Mode is a hard override: when on, the AI assistant is forced off
+-- regardless of ai_enabled (OSCP and similar exams forbid AI tools). It does
+-- NOT touch any other network feature — internet research / HackTricks stay
+-- available, since those are permitted during the exam.
+
+ALTER TABLE app_state ADD COLUMN ai_enabled INTEGER NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE app_state ADD COLUMN ai_provider TEXT NOT NULL DEFAULT 'ollama';
+--> statement-breakpoint
+ALTER TABLE app_state ADD COLUMN ai_base_url TEXT;
+--> statement-breakpoint
+ALTER TABLE app_state ADD COLUMN ai_model TEXT;
+--> statement-breakpoint
+ALTER TABLE app_state ADD COLUMN ai_api_key TEXT;
+--> statement-breakpoint
+ALTER TABLE app_state ADD COLUMN exam_mode INTEGER NOT NULL DEFAULT 0;

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1779100000000,
       "tag": "0021_add-port-fingerprints",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1779200000000,
+      "tag": "0022_add-ai-config-exam-mode",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -774,6 +774,20 @@ export const app_state = sqliteTable("app_state", {
    *  are explicit user overrides. Stored as TEXT; the repo narrows it
    *  to the ThemeMode union. v2.3.0 #3. */
   theme: text("theme").notNull().default("system"),
+  /** Optional AI co-pilot (v2.5.0). All opt-in; default OFF. When enabled,
+   *  defaults to a local provider so no scan data leaves the host unless the
+   *  operator points at a cloud provider. `ai_api_key` is server-only and is
+   *  never returned to the client. */
+  ai_enabled: integer("ai_enabled", { mode: "boolean" })
+    .notNull()
+    .default(false),
+  ai_provider: text("ai_provider").notNull().default("ollama"),
+  ai_base_url: text("ai_base_url"),
+  ai_model: text("ai_model"),
+  ai_api_key: text("ai_api_key"),
+  /** Exam Mode (v2.5.0): hard override that forces the AI assistant off
+   *  (OSCP-style exams forbid AI). Does not affect any other feature. */
+  exam_mode: integer("exam_mode", { mode: "boolean" }).notNull().default(false),
   updated_at: text("updated_at").notNull(),
 });
 


### PR DESCRIPTION
## Sprint 1a — AI foundation + Exam Mode (backend)

First half of Sprint 1. Lands the **data model + resolver** for the optional, local-first AI co-pilot and **Exam Mode**. **No UI and no outbound AI calls yet** — those are Sprint 1b (settings panel, badge, streaming proxy). Targets `develop` (beta line).

### Changes
- **migration 0022** — `app_state` gains `ai_enabled`, `ai_provider`, `ai_base_url`, `ai_model`, `ai_api_key`, `exam_mode`. All opt-in, default **OFF**; provider defaults to local **`ollama`**.
- **app-state-repo** — patch + `effectiveAppState` wired with env fallbacks (`RECON_AI_*`, `RECON_EXAM_MODE`). `ai_api_key` is server-only.
- **`src/lib/ai/config.ts`** — `effectiveAiConfig()` centralizes the three rules:
  1. **Exam Mode is a hard override** → AI off regardless of `ai_enabled` (OSCP forbids AI; nothing else touched).
  2. **Local-first** → unconfigured provider = Ollama on localhost (no silent cloud egress).
  3. **Cloud needs a key** → openai/openrouter disabled with reason `missing_key` until a key is set.
  `publicAiStatus()` strips the key + base URL for client use.
- **`GET /api/ai/status`** — client-safe `{enabled, reason, examMode, provider, model, hasKey, cloud}`.

### Tests
- 9 new cases for the resolver: defaults, enable-local, **exam-mode override**, cloud-missing-key, cloud-with-key, base/model override, unknown-provider fallback, **key never serialized**, env fallback + exam override.
- Full suite local: **537/537 passing**, `tsc --noEmit` clean.

> Note: while testing, my local dev `data/recon-deck.db` surfaced 43 pre-existing FK violations (orphaned `scan_history` rows) once migration 0022 triggered the post-migration FK check — environmental (dirty local DB), not from this change; CI runs against a fresh DB.

### Next (Sprint 1b)
Settings UI (provider/base-url/model/key + enable + Exam Mode toggle), the "EXAM MODE · AI off" badge, and the streaming proxy route `POST /api/ai` with prompt-injection hardening. Then cut `v2.5.0-beta.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)