### PR TITLE
feat(ai): AI settings panel + Exam Mode toggle + badge (Sprint 1b)

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -4,6 +4,7 @@ import { CommandPalette } from "@/components/CommandPalette";
 import { CheatSheetModal } from "@/components/CheatSheetModal";
 import { GlobalSearchModal } from "@/components/GlobalSearchModal";
 import { UpdateAvailableToast } from "@/components/UpdateAvailableToast";
+import { ExamModeBadge } from "@/components/ExamModeBadge";
 import { db, listSummaries, effectiveAppState } from "@/lib/db";
 import { ports as portsTable } from "@/lib/db/schema";
 import { getKb, matchPort } from "@/lib/kb";
@@ -86,6 +87,7 @@ export default function AppLayout({
       <CheatSheetModal />
       <GlobalSearchModal />
       <UpdateAvailableToast />
+      {cfg.examMode && <ExamModeBadge />}
     </>
   );
 }

--- a/app/(app)/settings/_actions.ts
+++ b/app/(app)/settings/_actions.ts
@@ -11,7 +11,8 @@
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { db, replayOnboarding, setAppState } from "@/lib/db";
-import type { ThemeMode } from "@/lib/db/app-state-repo";
+import type { ThemeMode, AppStatePatch } from "@/lib/db/app-state-repo";
+import { isAiProvider } from "@/lib/ai/providers";
 
 export async function replayOnboardingAction(): Promise<void> {
   replayOnboarding(db);
@@ -33,5 +34,63 @@ export async function setThemeAction(theme: ThemeMode): Promise<void> {
   }
   setAppState(db, { theme });
   // Layout-wide because the html className is set in the root layout.
+  revalidatePath("/", "layout");
+}
+
+/**
+ * Exam Mode — hard override that forces the AI assistant off (OSCP-style
+ * exams forbid AI). Layout-wide revalidate so the badge appears/disappears
+ * everywhere immediately.
+ */
+export async function setExamModeAction(enabled: boolean): Promise<void> {
+  if (typeof enabled !== "boolean") throw new Error("Invalid value.");
+  setAppState(db, { exam_mode: enabled });
+  revalidatePath("/", "layout");
+}
+
+export interface AiSettingsInput {
+  enabled: boolean;
+  provider: string;
+  baseUrl: string;
+  model: string;
+  /**
+   * undefined / "" → leave the stored key untouched (so saving other fields
+   * doesn't require re-typing it); a non-empty string → set it; null → clear.
+   */
+  apiKey?: string | null;
+}
+
+/**
+ * Persist the AI co-pilot config. The key is write-only from the client's
+ * perspective — it's never read back, and an empty submission keeps the
+ * existing one. Base URL / model empty → null so the provider preset default
+ * applies (resolved server-side in `effectiveAiConfig`).
+ */
+export async function setAiSettingsAction(
+  input: AiSettingsInput,
+): Promise<void> {
+  if (typeof input?.enabled !== "boolean") throw new Error("Invalid value.");
+  if (!isAiProvider(input.provider)) throw new Error("Invalid provider.");
+
+  const baseUrl = (input.baseUrl ?? "").trim();
+  if (baseUrl && !/^https?:\/\//i.test(baseUrl)) {
+    throw new Error("Base URL must start with http:// or https://");
+  }
+  const model = (input.model ?? "").trim();
+
+  const patch: AppStatePatch = {
+    ai_enabled: input.enabled,
+    ai_provider: input.provider,
+    ai_base_url: baseUrl || null,
+    ai_model: model || null,
+  };
+  if (input.apiKey === null) {
+    patch.ai_api_key = null; // explicit clear
+  } else if (typeof input.apiKey === "string" && input.apiKey.trim()) {
+    patch.ai_api_key = input.apiKey.trim();
+  }
+  // undefined / blank → omit, leaving the stored key as-is.
+
+  setAppState(db, patch);
   revalidatePath("/", "layout");
 }

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -16,7 +16,10 @@ import {
   listSummaries,
   listDeletedSummaries,
   effectiveAppState,
+  getAppState,
 } from "@/lib/db";
+import { normalizeProvider } from "@/lib/ai/providers";
+import { AiSettingsSection } from "@/components/AiSettingsSection";
 import { EngagementSettingsList } from "@/components/EngagementSettingsList";
 import { RecycleBinList } from "@/components/RecycleBinList";
 import { EditorIntegrationToggle } from "@/components/EditorIntegrationToggle";
@@ -31,6 +34,7 @@ export default function SettingsIndexPage() {
   const engagements = listSummaries(db);
   const deleted = listDeletedSummaries(db);
   const cfg = effectiveAppState(db);
+  const aiRaw = getAppState(db);
   const tools = detectToolPaths();
   const totalHosts = engagements.reduce((acc, e) => acc + e.host_count, 0);
   const totalPorts = engagements.reduce((acc, e) => acc + e.port_count, 0);
@@ -204,6 +208,32 @@ export default function SettingsIndexPage() {
           Off by default — opt in here per browser.
         </p>
         <EditorIntegrationToggle />
+      </section>
+
+      {/* v2.5.0: optional AI co-pilot + Exam Mode. */}
+      <section style={{ marginBottom: 32 }}>
+        <SectionLabel>AI assistant</SectionLabel>
+        <p
+          style={{
+            fontSize: 12,
+            color: "var(--fg-muted)",
+            margin: "6px 0 12px",
+          }}
+        >
+          Optional, off by default. Defaults to a local model (Ollama) so scan
+          data stays on your machine unless you pick a cloud provider. Exam Mode
+          hard-disables it for exams that forbid AI.
+        </p>
+        <AiSettingsSection
+          initial={{
+            enabled: aiRaw.ai_enabled,
+            provider: normalizeProvider(aiRaw.ai_provider),
+            baseUrl: aiRaw.ai_base_url ?? "",
+            model: aiRaw.ai_model ?? "",
+            hasKey: !!aiRaw.ai_api_key,
+            examMode: aiRaw.exam_mode,
+          }}
+        />
       </section>
 
       {/* v1.9.0: first-run / onboarding controls. */}

--- a/src/components/AiSettingsSection.tsx
+++ b/src/components/AiSettingsSection.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+/**
+ * AiSettingsSection — the /settings "AI assistant" card (v2.5.0).
+ *
+ * One surface for the optional, local-first AI co-pilot plus the Exam Mode
+ * override. Everything is opt-in and OFF by default. The API key is
+ * write-only from the client's side: the existing key is never sent down
+ * (only `hasKey`), and leaving the field blank on save keeps it.
+ *
+ * Exam Mode is wired separately and saves immediately — flipping it on
+ * disables the AI config below and the app-wide badge appears at once.
+ */
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { AlertTriangle, Lock } from "lucide-react";
+import {
+  AI_PROVIDERS,
+  AI_PROVIDER_ORDER,
+  type AiProvider,
+} from "@/lib/ai/providers";
+import {
+  setAiSettingsAction,
+  setExamModeAction,
+} from "../../app/(app)/settings/_actions";
+
+export interface AiSettingsInitial {
+  enabled: boolean;
+  provider: AiProvider;
+  baseUrl: string;
+  model: string;
+  hasKey: boolean;
+  examMode: boolean;
+}
+
+const card: React.CSSProperties = {
+  padding: "14px 16px",
+  borderRadius: 6,
+  border: "1px solid var(--border)",
+  background: "var(--bg-2)",
+};
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  marginTop: 4,
+  padding: "7px 9px",
+  borderRadius: 5,
+  border: "1px solid var(--border)",
+  background: "var(--bg-1)",
+  color: "var(--fg)",
+  fontSize: 12.5,
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 600,
+  color: "var(--fg-muted)",
+};
+
+export function AiSettingsSection({ initial }: { initial: AiSettingsInitial }) {
+  const [examMode, setExamMode] = useState(initial.examMode);
+  const [enabled, setEnabled] = useState(initial.enabled);
+  const [provider, setProvider] = useState<AiProvider>(initial.provider);
+  const [baseUrl, setBaseUrl] = useState(initial.baseUrl);
+  const [model, setModel] = useState(initial.model);
+  const [apiKey, setApiKey] = useState("");
+  const [hasKey, setHasKey] = useState(initial.hasKey);
+  const [clearKey, setClearKey] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const [examPending, startExamTransition] = useTransition();
+
+  const preset = AI_PROVIDERS[provider];
+
+  function toggleExam(next: boolean) {
+    const prev = examMode;
+    setExamMode(next);
+    startExamTransition(async () => {
+      try {
+        await setExamModeAction(next);
+        toast.success(next ? "Exam Mode on — AI disabled." : "Exam Mode off.");
+      } catch {
+        setExamMode(prev);
+        toast.error("Could not update Exam Mode.");
+      }
+    });
+  }
+
+  function save() {
+    startTransition(async () => {
+      try {
+        await setAiSettingsAction({
+          enabled,
+          provider,
+          baseUrl,
+          model,
+          apiKey: clearKey ? null : apiKey || undefined,
+        });
+        if (clearKey) {
+          setHasKey(false);
+          setClearKey(false);
+        } else if (apiKey.trim()) {
+          setHasKey(true);
+        }
+        setApiKey("");
+        toast.success("AI settings saved.");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Save failed.");
+      }
+    });
+  }
+
+  const aiDisabled = examMode; // exam mode hard-disables the config below
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      {/* Exam Mode */}
+      <div
+        style={{
+          ...card,
+          borderColor: examMode ? "var(--warning-border, #b45309)" : "var(--border)",
+          background: examMode ? "var(--warning-bg, rgba(180,83,9,0.12))" : "var(--bg-2)",
+        }}
+      >
+        <label className="flex items-center gap-3" style={{ cursor: "pointer" }}>
+          <input
+            type="checkbox"
+            checked={examMode}
+            disabled={examPending}
+            onChange={(e) => toggleExam(e.target.checked)}
+            style={{ accentColor: "var(--warning, #d97706)" }}
+          />
+          <div style={{ flex: 1 }}>
+            <div
+              style={{
+                fontSize: 13,
+                fontWeight: 600,
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+              }}
+            >
+              <Lock size={13} /> Exam Mode
+            </div>
+            <div style={{ marginTop: 4, fontSize: 12, color: "var(--fg-muted)", lineHeight: 1.5 }}>
+              Hard-disables the AI assistant — for exams that forbid AI (e.g.
+              OSCP). Internet research, HackTricks links, and searchsploit stay
+              available; only the AI is turned off.
+            </div>
+          </div>
+        </label>
+      </div>
+
+      {/* AI config */}
+      <div style={{ ...card, opacity: aiDisabled ? 0.55 : 1 }}>
+        <label className="flex items-center gap-3" style={{ cursor: aiDisabled ? "not-allowed" : "pointer" }}>
+          <input
+            type="checkbox"
+            checked={enabled}
+            disabled={aiDisabled || pending}
+            onChange={(e) => setEnabled(e.target.checked)}
+            style={{ accentColor: "var(--accent)" }}
+          />
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 13, fontWeight: 600 }}>
+              Enable AI assistant
+            </div>
+            <div style={{ marginTop: 4, fontSize: 12, color: "var(--fg-muted)", lineHeight: 1.5 }}>
+              Off by default. When on, defaults to a local model so nothing
+              leaves your machine unless you pick a cloud provider below.
+            </div>
+          </div>
+        </label>
+
+        <div style={{ marginTop: 14, display: aiDisabled ? "none" : "block" }}>
+          {/* Provider */}
+          <div style={labelStyle}>PROVIDER</div>
+          <div className="grid grid-cols-3 gap-2" style={{ marginTop: 6, marginBottom: 12 }}>
+            {AI_PROVIDER_ORDER.map((p) => {
+              const active = provider === p;
+              return (
+                <button
+                  key={p}
+                  type="button"
+                  onClick={() => setProvider(p)}
+                  disabled={pending}
+                  style={{
+                    padding: "8px 6px",
+                    borderRadius: 6,
+                    border: `1px solid ${active ? "var(--accent-border)" : "var(--border)"}`,
+                    background: active ? "var(--accent-bg)" : "var(--bg-1)",
+                    color: active ? "var(--accent)" : "var(--fg-muted)",
+                    fontSize: 11.5,
+                    fontWeight: 500,
+                    cursor: pending ? "wait" : "pointer",
+                  }}
+                >
+                  {AI_PROVIDERS[p].label}
+                </button>
+              );
+            })}
+          </div>
+
+          {preset.cloud && (
+            <div
+              style={{
+                display: "flex",
+                gap: 8,
+                alignItems: "flex-start",
+                padding: "8px 10px",
+                marginBottom: 12,
+                borderRadius: 5,
+                border: "1px solid var(--warning-border, #b45309)",
+                background: "var(--warning-bg, rgba(180,83,9,0.12))",
+                fontSize: 11.5,
+                color: "var(--fg-muted)",
+                lineHeight: 1.5,
+              }}
+            >
+              <AlertTriangle size={13} style={{ flexShrink: 0, marginTop: 1 }} />
+              <span>
+                <strong>Cloud provider.</strong> Anything the assistant sends
+                (scan output, banners, notes) leaves your machine and goes to{" "}
+                {preset.label}. Avoid on engagements with strict NDAs — prefer a
+                local model.
+              </span>
+            </div>
+          )}
+
+          {/* Base URL */}
+          <label style={{ display: "block", marginBottom: 12 }}>
+            <span style={labelStyle}>BASE URL</span>
+            <input
+              type="text"
+              value={baseUrl}
+              placeholder={preset.defaultBaseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              disabled={pending}
+              spellCheck={false}
+              style={inputStyle}
+            />
+          </label>
+
+          {/* Model */}
+          <label style={{ display: "block", marginBottom: 12 }}>
+            <span style={labelStyle}>MODEL</span>
+            <input
+              type="text"
+              value={model}
+              placeholder={preset.defaultModel}
+              onChange={(e) => setModel(e.target.value)}
+              disabled={pending}
+              spellCheck={false}
+              style={inputStyle}
+            />
+          </label>
+
+          {/* API key */}
+          <label style={{ display: "block", marginBottom: 8 }}>
+            <span style={labelStyle}>
+              API KEY {preset.needsKey ? "(required)" : "(not needed for local)"}
+            </span>
+            <input
+              type="password"
+              value={apiKey}
+              placeholder={
+                clearKey
+                  ? "(will be cleared on save)"
+                  : hasKey
+                    ? "•••••••• (saved — leave blank to keep)"
+                    : "sk-…"
+              }
+              onChange={(e) => {
+                setApiKey(e.target.value);
+                if (e.target.value) setClearKey(false);
+              }}
+              disabled={pending || clearKey}
+              autoComplete="off"
+              spellCheck={false}
+              style={inputStyle}
+            />
+            {hasKey && !clearKey && (
+              <button
+                type="button"
+                onClick={() => setClearKey(true)}
+                disabled={pending}
+                style={{
+                  marginTop: 6,
+                  fontSize: 11,
+                  color: "var(--fg-subtle)",
+                  textDecoration: "underline",
+                  cursor: "pointer",
+                  background: "none",
+                  border: "none",
+                  padding: 0,
+                }}
+              >
+                Clear saved key
+              </button>
+            )}
+          </label>
+
+          <button
+            type="button"
+            onClick={save}
+            disabled={pending}
+            style={{
+              marginTop: 6,
+              padding: "8px 16px",
+              borderRadius: 6,
+              border: "1px solid var(--accent-border)",
+              background: "var(--accent-bg)",
+              color: "var(--accent)",
+              fontSize: 12.5,
+              fontWeight: 600,
+              cursor: pending ? "wait" : "pointer",
+            }}
+          >
+            {pending ? "Saving…" : "Save AI settings"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ExamModeBadge.tsx
+++ b/src/components/ExamModeBadge.tsx
@@ -1,0 +1,41 @@
+/**
+ * ExamModeBadge — fixed pill shown app-wide while Exam Mode is on (v2.5.0).
+ *
+ * Purpose is reassurance: during an exam that forbids AI, the operator wants
+ * a constant, visible confirmation that the assistant is off. Rendered by the
+ * (app) layout only when `exam_mode` is set. Server component — pure markup,
+ * no client JS.
+ */
+
+import { Lock } from "lucide-react";
+
+export function ExamModeBadge() {
+  return (
+    <div
+      role="status"
+      aria-label="Exam Mode active — AI assistant disabled"
+      style={{
+        position: "fixed",
+        bottom: 12,
+        left: 12,
+        zIndex: 50,
+        display: "flex",
+        alignItems: "center",
+        gap: 6,
+        padding: "5px 10px",
+        borderRadius: 999,
+        border: "1px solid var(--warning-border, #b45309)",
+        background: "var(--warning-bg, rgba(180,83,9,0.14))",
+        color: "var(--warning, #d97706)",
+        fontSize: 10.5,
+        fontWeight: 700,
+        letterSpacing: "0.06em",
+        pointerEvents: "none",
+        backdropFilter: "blur(4px)",
+      }}
+    >
+      <Lock size={11} />
+      EXAM MODE · AI OFF
+    </div>
+  );
+}

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -21,51 +21,21 @@ import "server-only";
  */
 
 import { effectiveAppState, type Db } from "@/lib/db/app-state-repo";
+import {
+  AI_PROVIDERS,
+  normalizeProvider,
+  type AiProvider,
+} from "./providers";
 
-export type AiProvider = "ollama" | "openai" | "openrouter";
-
-export interface ProviderPreset {
-  label: string;
-  defaultBaseUrl: string;
-  defaultModel: string;
-  /** Cloud providers require an API key; local ones do not. */
-  needsKey: boolean;
-  /** True when requests leave the host (privacy-relevant for scan data). */
-  cloud: boolean;
-}
-
-export const AI_PROVIDERS: Record<AiProvider, ProviderPreset> = {
-  ollama: {
-    label: "Ollama (local)",
-    defaultBaseUrl: "http://127.0.0.1:11434/v1",
-    defaultModel: "llama3.1",
-    needsKey: false,
-    cloud: false,
-  },
-  openai: {
-    label: "OpenAI",
-    defaultBaseUrl: "https://api.openai.com/v1",
-    defaultModel: "gpt-4.1-mini",
-    needsKey: true,
-    cloud: true,
-  },
-  openrouter: {
-    label: "OpenRouter",
-    defaultBaseUrl: "https://openrouter.ai/api/v1",
-    defaultModel: "openai/gpt-4.1-mini",
-    needsKey: true,
-    cloud: true,
-  },
-};
-
-export function isAiProvider(v: string): v is AiProvider {
-  return v === "ollama" || v === "openai" || v === "openrouter";
-}
-
-/** Unknown/garbage provider values fall back to the local default. */
-export function normalizeProvider(raw: string): AiProvider {
-  return isAiProvider(raw) ? raw : "ollama";
-}
+// Re-export the client-safe presets/helpers so existing importers of this
+// module (and tests) keep working unchanged.
+export {
+  AI_PROVIDERS,
+  AI_PROVIDER_ORDER,
+  isAiProvider,
+  normalizeProvider,
+} from "./providers";
+export type { AiProvider, ProviderPreset } from "./providers";
 
 export type AiDisabledReason = "exam_mode" | "disabled" | "missing_key" | null;
 

--- a/src/lib/ai/providers.ts
+++ b/src/lib/ai/providers.ts
@@ -1,0 +1,54 @@
+/**
+ * AI provider presets — client-safe (NO `server-only`).
+ *
+ * Pure data + helpers shared by the server resolver (`config.ts`) and the
+ * client settings UI (`AiSettingsSection`). Keep this free of any DB / fs /
+ * secret access so it can be imported into a client component bundle.
+ */
+
+export type AiProvider = "ollama" | "openai" | "openrouter";
+
+export interface ProviderPreset {
+  label: string;
+  defaultBaseUrl: string;
+  defaultModel: string;
+  /** Cloud providers require an API key; local ones do not. */
+  needsKey: boolean;
+  /** True when requests leave the host (privacy-relevant for scan data). */
+  cloud: boolean;
+}
+
+export const AI_PROVIDERS: Record<AiProvider, ProviderPreset> = {
+  ollama: {
+    label: "Ollama (local)",
+    defaultBaseUrl: "http://127.0.0.1:11434/v1",
+    defaultModel: "llama3.1",
+    needsKey: false,
+    cloud: false,
+  },
+  openai: {
+    label: "OpenAI",
+    defaultBaseUrl: "https://api.openai.com/v1",
+    defaultModel: "gpt-4.1-mini",
+    needsKey: true,
+    cloud: true,
+  },
+  openrouter: {
+    label: "OpenRouter",
+    defaultBaseUrl: "https://openrouter.ai/api/v1",
+    defaultModel: "openai/gpt-4.1-mini",
+    needsKey: true,
+    cloud: true,
+  },
+};
+
+export const AI_PROVIDER_ORDER: AiProvider[] = ["ollama", "openai", "openrouter"];
+
+export function isAiProvider(v: string): v is AiProvider {
+  return v === "ollama" || v === "openai" || v === "openrouter";
+}
+
+/** Unknown/garbage provider values fall back to the local default. */
+export function normalizeProvider(raw: string): AiProvider {
+  return isAiProvider(raw) ? raw : "ollama";
+}


### PR DESCRIPTION
## Sprint 1b — AI settings UI + Exam Mode (visible)

Second half of Sprint 1, building on #45's resolver. Adds the **/settings "AI assistant" card**, the **Exam Mode toggle**, and the app-wide **"EXAM MODE · AI OFF" badge**. Still **no outbound AI calls** — the streaming proxy + actual features (Explain, suggest-commands) are Sprint 2. Targets `develop`.

### Changes
- **`src/lib/ai/providers.ts`** — client-safe provider presets/helpers split out of `config.ts` (now re-exports them) so the client UI imports presets without pulling in the `server-only` resolver.
- **`settings/_actions.ts`** — `setExamModeAction` + `setAiSettingsAction`. The API key is **write-only**: never read back to the client, blank submit keeps the stored key, `null` clears. Provider allowlisted; base URL scheme-checked.
- **`AiSettingsSection`** — one card: Exam Mode toggle (saves immediately, hard-disables the config), enable + provider (Ollama/OpenAI/OpenRouter) + base URL + model + write-only key, plus a **cloud-egress warning** when a cloud provider is selected.
- **`ExamModeBadge`** — fixed `EXAM MODE · AI OFF` pill rendered by the (app) layout whenever `exam_mode` is set (reassurance during exams).

### Validation
- Full suite **537/537** ✅, `tsc --noEmit` ✅, **production build OK** ✅ (client/server boundaries clean — the client panel imports only the non-`server-only` providers module).
- This PR runs the full CI on develop now that #/ci gates the develop line.

### Next (Sprint 2)
Streaming proxy `POST /api/ai` with prompt-injection hardening + the first feature ("Explain this" on a port card), then cut `v2.5.0-beta.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)