### PR TITLE
feat(ai): "Explain this" button + streaming panel (Sprint 2b)

### DIFF
--- a/src/components/ExplainButton.tsx
+++ b/src/components/ExplainButton.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+/**
+ * ExplainButton — "Explain this" AI affordance for a port (v2.5.0, Sprint 2).
+ *
+ * Renders nothing unless the AI co-pilot is enabled (and not in Exam Mode).
+ * On click it POSTs the port's scan context to the server proxy /api/ai and
+ * streams the plain-text explanation into a panel, token by token.
+ *
+ * Suggest-only: this never runs a command — it describes the scan output and
+ * surfaces considerations. Output carries an explicit "verify" disclaimer.
+ */
+
+import { useState } from "react";
+import { Sparkles, Loader2, X } from "lucide-react";
+import { useAiStatus } from "@/components/ai/useAiStatus";
+
+export interface ExplainContext {
+  port: number;
+  protocol?: string | null;
+  service?: string | null;
+  version?: string | null;
+  scanOutput: string;
+}
+
+export function ExplainButton(props: ExplainContext) {
+  const status = useAiStatus();
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [streaming, setStreaming] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  // Hidden entirely unless the assistant is usable right now.
+  if (!status || !status.enabled) return null;
+
+  async function run() {
+    setOpen(true);
+    setText("");
+    setError(null);
+    setStreaming(true);
+    try {
+      const res = await fetch("/api/ai", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          task: "explain",
+          context: {
+            port: props.port,
+            protocol: props.protocol ?? null,
+            service: props.service ?? null,
+            version: props.version ?? null,
+            scanOutput: props.scanOutput,
+          },
+        }),
+      });
+      if (!res.ok || !res.body) {
+        const j = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(j.error || `Request failed (${res.status})`);
+      }
+      const reader = res.body.getReader();
+      const dec = new TextDecoder();
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const chunk = dec.decode(value, { stream: true });
+        setText((t) => t + chunk);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not reach the assistant.");
+    } finally {
+      setStreaming(false);
+    }
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={run}
+        disabled={streaming}
+        title={`Explain with AI (${status.provider}${status.cloud ? " · cloud" : " · local"})`}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 5,
+          padding: "4px 9px",
+          borderRadius: 5,
+          border: "1px solid var(--accent-border)",
+          background: "var(--accent-bg)",
+          color: "var(--accent)",
+          fontSize: 11.5,
+          fontWeight: 600,
+          cursor: streaming ? "wait" : "pointer",
+        }}
+      >
+        {streaming ? (
+          <Loader2 size={12} className="animate-spin" />
+        ) : (
+          <Sparkles size={12} />
+        )}
+        {streaming ? "Explaining…" : "Explain"}
+      </button>
+
+      {open && (
+        <div
+          style={{
+            marginTop: 8,
+            border: "1px solid var(--accent-border)",
+            borderRadius: 6,
+            background: "var(--bg-1)",
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              padding: "5px 10px",
+              borderBottom: "1px solid var(--border)",
+              background: "var(--bg-2)",
+              fontSize: 10.5,
+              fontWeight: 600,
+              letterSpacing: "0.04em",
+              color: "var(--fg-subtle)",
+            }}
+          >
+            <span>
+              AI EXPLANATION · {status.model}
+              {status.cloud ? " · cloud" : " · local"}
+            </span>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label="Close"
+              style={{
+                background: "none",
+                border: "none",
+                color: "var(--fg-subtle)",
+                cursor: "pointer",
+                display: "flex",
+              }}
+            >
+              <X size={13} />
+            </button>
+          </div>
+          <div style={{ padding: 10 }}>
+            {error ? (
+              <div style={{ fontSize: 12, color: "var(--danger, #dc2626)" }}>
+                {error}
+              </div>
+            ) : (
+              <div
+                style={{
+                  fontSize: 12.5,
+                  lineHeight: 1.55,
+                  color: "var(--fg)",
+                  whiteSpace: "pre-wrap",
+                }}
+              >
+                {text}
+                {streaming && (
+                  <span style={{ opacity: 0.5 }}>▍</span>
+                )}
+              </div>
+            )}
+            {!streaming && !error && text && (
+              <div
+                style={{
+                  marginTop: 10,
+                  fontSize: 10.5,
+                  color: "var(--fg-subtle)",
+                  fontStyle: "italic",
+                }}
+              >
+                AI-generated — verify before acting. The model only describes
+                the scan; it does not run anything.
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/PortDetailPane.tsx
+++ b/src/components/PortDetailPane.tsx
@@ -25,6 +25,7 @@ import type { ScriptElem, ScriptTable } from "@/lib/parser/types";
 import type { PortEvidence } from "@/lib/db/schema";
 import { useUIStore } from "@/lib/store";
 import { isAllowedUrl } from "@/lib/security/validate-url";
+import { ExplainButton } from "@/components/ExplainButton";
 
 type FindingSeverity = "info" | "low" | "medium" | "high" | "critical";
 
@@ -294,6 +295,25 @@ export function PortDetailPane({
 
         {scripts.length > 0 && (
           <Section label="NSE Script Output" count={scripts.length}>
+            {(() => {
+              const [portStr, proto] = (servicePortLabel ?? "").split("/");
+              const portNum = parseInt(portStr ?? "", 10);
+              if (!Number.isInteger(portNum)) return null;
+              const scanOutput = scripts
+                .map((s) => `# ${s.script_id}\n${s.output}`)
+                .join("\n\n");
+              return (
+                <div style={{ marginBottom: 8 }}>
+                  <ExplainButton
+                    port={portNum}
+                    protocol={proto ?? null}
+                    service={serviceName ?? null}
+                    version={exploitQuery ?? null}
+                    scanOutput={scanOutput}
+                  />
+                </div>
+              );
+            })()}
             <div className="flex flex-col gap-2">
               {scripts.map((s) => (
                 <div

--- a/src/components/ai/useAiStatus.ts
+++ b/src/components/ai/useAiStatus.ts
@@ -1,0 +1,53 @@
+"use client";
+
+/**
+ * useAiStatus — shared client hook for the AI co-pilot's availability.
+ *
+ * Hits GET /api/ai/status once and caches the promise at module scope so
+ * many port cards mounting ExplainButton share a single request. Returns
+ * `null` while loading; components hide their AI affordances until enabled.
+ *
+ * Never carries secrets — /api/ai/status is the client-safe projection.
+ */
+
+import { useEffect, useState } from "react";
+
+export interface AiStatus {
+  enabled: boolean;
+  reason: "exam_mode" | "disabled" | "missing_key" | null;
+  examMode: boolean;
+  provider: string;
+  model: string;
+  hasKey: boolean;
+  cloud: boolean;
+}
+
+let cached: Promise<AiStatus | null> | null = null;
+
+function fetchStatus(): Promise<AiStatus | null> {
+  if (!cached) {
+    cached = fetch("/api/ai/status", { cache: "no-store" })
+      .then((r) => (r.ok ? (r.json() as Promise<AiStatus>) : null))
+      .catch(() => null);
+  }
+  return cached;
+}
+
+/** Test/util escape hatch — drop the cached status so the next call refetches. */
+export function resetAiStatusCache(): void {
+  cached = null;
+}
+
+export function useAiStatus(): AiStatus | null {
+  const [status, setStatus] = useState<AiStatus | null>(null);
+  useEffect(() => {
+    let alive = true;
+    fetchStatus().then((s) => {
+      if (alive) setStatus(s);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return status;
+}


### PR DESCRIPTION
## Sprint 2b — "Explain this" UI (first user-facing AI feature)

Wires the Sprint 2a proxy to a real affordance on port cards. Targets `develop`. After this merges → cut **v2.5.0-beta.2**.

### Changes
- **`useAiStatus`** — shared client hook; one cached `GET /api/ai/status` so every port card shares a single availability check.
- **`ExplainButton`** — renders **nothing** unless AI is enabled (hidden in Exam Mode / disabled / no key). On click, POSTs the port's NSE scan output to `/api/ai` and **streams** the explanation token-by-token into a panel, with a local/cloud + model label and an explicit *"AI-generated — verify; it does not run anything"* disclaimer.
- **`PortDetailPane`** — assembles the port context (port/proto from the label, service, version, joined NSE output) and mounts `ExplainButton` in the NSE Script Output section.

### Design
Inline co-pilot (not a chatbot), suggest-only, hidden when unavailable so it never nags. The whole feature no-ops cleanly when AI is off — zero impact on the default offline experience.

### Validation
- **547/547** tests, `tsc` clean, **production build OK**. (UI components aren't unit-tested here, consistent with the repo; the backend prompt/stream logic is covered in 2a.)

### After merge
Cut `v2.5.0-beta.2` so the full flow (configure AI in Settings → Explain on a port → Exam Mode hides it) is testable in a real beta image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)