### PR TITLE
feat(ai): model picker (fetch provider model list)

### DIFF
--- a/app/api/ai/models/route.ts
+++ b/app/api/ai/models/route.ts
@@ -1,0 +1,44 @@
+/**
+ * GET /api/ai/models — list the configured provider's available models (v2.5.0).
+ *
+ * Drives the model picker in Settings. It's a configuration helper, so it works
+ * even when the assistant itself is gated off (disabled / Exam Mode) — but a
+ * cloud provider still needs its key saved first. The key never leaves the
+ * server; the browser only ever sees the resulting id list.
+ */
+
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { effectiveAiConfig } from "@/lib/ai/config";
+import { listModels, AiUpstreamError } from "@/lib/ai/client";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const cfg = effectiveAiConfig(db);
+  if (cfg.cloud && !cfg.hasKey) {
+    return NextResponse.json(
+      { error: "Save an API key first, then load models.", models: [] },
+      { status: 400 },
+    );
+  }
+  try {
+    const models = await listModels({
+      baseUrl: cfg.baseUrl,
+      apiKey: cfg.apiKey,
+      model: cfg.model,
+    });
+    return NextResponse.json({ models });
+  } catch (err) {
+    if (err instanceof AiUpstreamError) {
+      return NextResponse.json(
+        { error: err.message, models: [] },
+        { status: err.status },
+      );
+    }
+    return NextResponse.json(
+      { error: "Could not reach the provider.", models: [] },
+      { status: 503 },
+    );
+  }
+}

--- a/src/components/AiSettingsSection.tsx
+++ b/src/components/AiSettingsSection.tsx
@@ -69,6 +69,31 @@ export function AiSettingsSection({ initial }: { initial: AiSettingsInitial }) {
   const [clearKey, setClearKey] = useState(false);
   const [pending, startTransition] = useTransition();
   const [examPending, startExamTransition] = useTransition();
+  const [models, setModels] = useState<string[]>([]);
+  const [modelsLoading, setModelsLoading] = useState(false);
+  const [modelsMsg, setModelsMsg] = useState<string | null>(null);
+
+  async function loadModels() {
+    setModelsLoading(true);
+    setModelsMsg(null);
+    try {
+      const res = await fetch("/api/ai/models", { cache: "no-store" });
+      const json = (await res.json().catch(() => ({}))) as {
+        models?: string[];
+        error?: string;
+      };
+      if (!res.ok) throw new Error(json.error || `Failed (${res.status})`);
+      const list = Array.isArray(json.models) ? json.models : [];
+      setModels(list);
+      setModelsMsg(
+        list.length ? `${list.length} models loaded` : "No models returned",
+      );
+    } catch (e) {
+      setModelsMsg(e instanceof Error ? e.message : "Could not load models");
+    } finally {
+      setModelsLoading(false);
+    }
+  }
 
   const preset = AI_PROVIDERS[provider];
 
@@ -182,7 +207,11 @@ export function AiSettingsSection({ initial }: { initial: AiSettingsInitial }) {
                 <button
                   key={p}
                   type="button"
-                  onClick={() => setProvider(p)}
+                  onClick={() => {
+                    setProvider(p);
+                    setModels([]);
+                    setModelsMsg(null);
+                  }}
                   disabled={pending}
                   style={{
                     padding: "8px 6px",
@@ -244,15 +273,54 @@ export function AiSettingsSection({ initial }: { initial: AiSettingsInitial }) {
           {/* Model */}
           <label style={{ display: "block", marginBottom: 12 }}>
             <span style={labelStyle}>MODEL</span>
-            <input
-              type="text"
-              value={model}
-              placeholder={preset.defaultModel}
-              onChange={(e) => setModel(e.target.value)}
-              disabled={pending}
-              spellCheck={false}
-              style={inputStyle}
-            />
+            <div style={{ display: "flex", gap: 6, marginTop: 4 }}>
+              <input
+                type="text"
+                list="ai-model-list"
+                value={model}
+                placeholder={preset.defaultModel}
+                onChange={(e) => setModel(e.target.value)}
+                disabled={pending}
+                spellCheck={false}
+                style={{ ...inputStyle, marginTop: 0, flex: 1 }}
+              />
+              <datalist id="ai-model-list">
+                {models.map((m) => (
+                  <option key={m} value={m} />
+                ))}
+              </datalist>
+              <button
+                type="button"
+                onClick={loadModels}
+                disabled={modelsLoading || pending}
+                title="Fetch the provider's model list (uses the saved config)"
+                style={{
+                  flexShrink: 0,
+                  padding: "0 12px",
+                  borderRadius: 5,
+                  border: "1px solid var(--border)",
+                  background: "var(--bg-1)",
+                  color: "var(--fg-muted)",
+                  fontSize: 11.5,
+                  fontWeight: 600,
+                  cursor: modelsLoading ? "wait" : "pointer",
+                }}
+              >
+                {modelsLoading ? "Loading…" : "Load models"}
+              </button>
+            </div>
+            {modelsMsg && (
+              <div
+                style={{
+                  marginTop: 5,
+                  fontSize: 10.5,
+                  color: "var(--fg-subtle)",
+                }}
+              >
+                {modelsMsg} · pick from the list or type a model id. Save the
+                provider + key first if the list is empty.
+              </div>
+            )}
           </label>
 
           {/* API key */}

--- a/src/lib/ai/__tests__/client.test.ts
+++ b/src/lib/ai/__tests__/client.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   streamChatCompletion,
   chatCompletion,
+  listModels,
   AiUpstreamError,
 } from "../client.js";
 
@@ -128,5 +129,49 @@ describe("ai/client chatCompletion (non-streaming)", () => {
       vi.fn().mockResolvedValue(new Response("bad", { status: 500 })),
     );
     await expect(chatCompletion(cfg, [])).rejects.toBeInstanceOf(AiUpstreamError);
+  });
+});
+
+describe("ai/client listModels", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("parses, de-dupes and sorts model ids from /models", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: [
+              { id: "gpt-4o-mini" },
+              { id: "gpt-4o" },
+              { id: "gpt-4o-mini" },
+              { not_an_id: true },
+            ],
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    const out = await listModels(cfg);
+    expect(out).toEqual(["gpt-4o", "gpt-4o-mini"]);
+  });
+
+  it("hits the /models endpoint with the auth header when keyed", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await listModels({ baseUrl: "https://openrouter.ai/api/v1", apiKey: "sk-or", model: "x" });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://openrouter.ai/api/v1/models");
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer sk-or");
+  });
+
+  it("throws AiUpstreamError on non-2xx", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("nope", { status: 401 })),
+    );
+    await expect(listModels(cfg)).rejects.toBeInstanceOf(AiUpstreamError);
   });
 });

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -137,6 +137,40 @@ export async function chatCompletion(
 }
 
 /**
+ * List available model ids from an OpenAI-compatible `GET /models`. Used by the
+ * settings UI to populate a model picker. OpenAI, OpenRouter, Ollama and
+ * LM Studio all expose this. Returns the de-duped, sorted id list.
+ */
+export async function listModels(
+  cfg: StreamClientConfig,
+  opts: { timeoutMs?: number; signal?: AbortSignal } = {},
+): Promise<string[]> {
+  const signal = combineSignals(opts.timeoutMs ?? 15_000, opts.signal);
+  const headers: Record<string, string> = {};
+  if (cfg.apiKey) headers["Authorization"] = `Bearer ${cfg.apiKey}`;
+
+  const res = await fetch(`${cfg.baseUrl.replace(/\/$/, "")}/models`, {
+    headers,
+    signal,
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    let detail = "";
+    try {
+      detail = (await res.text()).slice(0, 200);
+    } catch {
+      /* ignore */
+    }
+    throw new AiUpstreamError(`Provider returned ${res.status}${detail ? `: ${detail}` : ""}`, res.status);
+  }
+  const json = (await res.json()) as { data?: Array<{ id?: unknown }> };
+  const ids = (json?.data ?? [])
+    .map((m) => m?.id)
+    .filter((x): x is string => typeof x === "string" && x.length > 0);
+  return Array.from(new Set(ids)).sort();
+}
+
+/**
  * Transform an OpenAI-style SSE byte stream into a plain UTF-8 text stream of
  * just the assistant deltas. Buffers across chunk boundaries; tolerates
  * keepalive comments and the terminal `[DONE]` sentinel.


### PR DESCRIPTION
## Model picker

The model field was free-text only — error-prone with OpenRouter's large catalog. Adds a provider-driven model list.

- **client.ts `listModels()`** — `GET {baseUrl}/models` (OpenAI/OpenRouter/Ollama/LM Studio all expose it), de-duped + sorted.
- **`GET /api/ai/models`** — returns the configured provider's models. Works even when the assistant is gated off (config helper), but a cloud provider needs its key saved first. **Key stays server-side**; client only sees ids.
- **AiSettingsSection** — a "Load models" button populates a `<datalist>`, turning the model input into an autocomplete picker (free-text fallback kept); switching provider clears the stale list.

UX note: the picker uses the **saved** config (so the key never re-crosses the wire) — save provider + key first, then Load models.

### Validation
- **558/558** tests (+3), `tsc` clean, build OK (`/api/ai/models`).

Targets `develop`. After this, ready for the live OpenRouter key test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)