### PR TITLE
feat(ai): searchable model picker + pricing + cost estimate

### DIFF
--- a/src/components/AiSettingsSection.tsx
+++ b/src/components/AiSettingsSection.tsx
@@ -18,8 +18,19 @@ import { AlertTriangle, Lock } from "lucide-react";
 import {
   AI_PROVIDERS,
   AI_PROVIDER_ORDER,
+  RECOMMENDED_MODEL_IDS,
+  estimateTargetCostUSD,
+  pricePerMillion,
   type AiProvider,
 } from "@/lib/ai/providers";
+
+interface ModelInfo {
+  id: string;
+  name?: string;
+  promptPrice?: number;
+  completionPrice?: number;
+  contextLength?: number;
+}
 import {
   setAiSettingsAction,
   setExamModeAction,
@@ -69,7 +80,8 @@ export function AiSettingsSection({ initial }: { initial: AiSettingsInitial }) {
   const [clearKey, setClearKey] = useState(false);
   const [pending, startTransition] = useTransition();
   const [examPending, startExamTransition] = useTransition();
-  const [models, setModels] = useState<string[]>([]);
+  const [models, setModels] = useState<ModelInfo[]>([]);
+  const [modelQuery, setModelQuery] = useState("");
   const [modelsLoading, setModelsLoading] = useState(false);
   const [modelsMsg, setModelsMsg] = useState<string | null>(null);
 
@@ -79,7 +91,7 @@ export function AiSettingsSection({ initial }: { initial: AiSettingsInitial }) {
     try {
       const res = await fetch("/api/ai/models", { cache: "no-store" });
       const json = (await res.json().catch(() => ({}))) as {
-        models?: string[];
+        models?: ModelInfo[];
         error?: string;
       };
       if (!res.ok) throw new Error(json.error || `Failed (${res.status})`);
@@ -271,12 +283,11 @@ export function AiSettingsSection({ initial }: { initial: AiSettingsInitial }) {
           </label>
 
           {/* Model */}
-          <label style={{ display: "block", marginBottom: 12 }}>
+          <div style={{ marginBottom: 12 }}>
             <span style={labelStyle}>MODEL</span>
             <div style={{ display: "flex", gap: 6, marginTop: 4 }}>
               <input
                 type="text"
-                list="ai-model-list"
                 value={model}
                 placeholder={preset.defaultModel}
                 onChange={(e) => setModel(e.target.value)}
@@ -284,11 +295,6 @@ export function AiSettingsSection({ initial }: { initial: AiSettingsInitial }) {
                 spellCheck={false}
                 style={{ ...inputStyle, marginTop: 0, flex: 1 }}
               />
-              <datalist id="ai-model-list">
-                {models.map((m) => (
-                  <option key={m} value={m} />
-                ))}
-              </datalist>
               <button
                 type="button"
                 onClick={loadModels}
@@ -309,19 +315,138 @@ export function AiSettingsSection({ initial }: { initial: AiSettingsInitial }) {
                 {modelsLoading ? "Loading…" : "Load models"}
               </button>
             </div>
+
+            {/* cost estimate for the selected model */}
+            {(() => {
+              const sel = models.find((m) => m.id === model);
+              const cost = sel
+                ? estimateTargetCostUSD(sel.promptPrice, sel.completionPrice)
+                : null;
+              if (!sel || cost === null) return null;
+              return (
+                <div style={{ marginTop: 5, fontSize: 10.5, color: "var(--fg-subtle)" }}>
+                  ≈ <strong style={{ color: "var(--fg-muted)" }}>${cost < 0.01 ? cost.toFixed(4) : cost.toFixed(2)}</strong>{" "}
+                  for a typical target (~15 explain/suggest calls) · in $
+                  {pricePerMillion(sel.promptPrice)?.toFixed(2)} / out $
+                  {pricePerMillion(sel.completionPrice)?.toFixed(2)} per 1M tokens
+                </div>
+              );
+            })()}
+
             {modelsMsg && (
-              <div
-                style={{
-                  marginTop: 5,
-                  fontSize: 10.5,
-                  color: "var(--fg-subtle)",
-                }}
-              >
-                {modelsMsg} · pick from the list or type a model id. Save the
-                provider + key first if the list is empty.
+              <div style={{ marginTop: 5, fontSize: 10.5, color: "var(--fg-subtle)" }}>
+                {modelsMsg}
               </div>
             )}
-          </label>
+
+            {/* searchable model list */}
+            {models.length > 0 && (
+              <div
+                style={{
+                  marginTop: 8,
+                  border: "1px solid var(--border)",
+                  borderRadius: 6,
+                  background: "var(--bg-1)",
+                  overflow: "hidden",
+                }}
+              >
+                <input
+                  type="text"
+                  placeholder="Search models…"
+                  value={modelQuery}
+                  onChange={(e) => setModelQuery(e.target.value)}
+                  spellCheck={false}
+                  style={{
+                    width: "100%",
+                    padding: "7px 9px",
+                    border: "none",
+                    borderBottom: "1px solid var(--border)",
+                    background: "var(--bg-2)",
+                    color: "var(--fg)",
+                    fontSize: 12,
+                  }}
+                />
+                <div style={{ maxHeight: 210, overflowY: "auto" }}>
+                  {(() => {
+                    const q = modelQuery.trim().toLowerCase();
+                    const match = (m: ModelInfo) =>
+                      !q ||
+                      m.id.toLowerCase().includes(q) ||
+                      (m.name ?? "").toLowerCase().includes(q);
+                    const filtered = models.filter(match);
+                    const rec = new Set(RECOMMENDED_MODEL_IDS);
+                    const recommended = filtered.filter((m) => rec.has(m.id));
+                    const rest = filtered.filter((m) => !rec.has(m.id));
+                    const row = (m: ModelInfo, star: boolean) => {
+                      const active = m.id === model;
+                      const inM = pricePerMillion(m.promptPrice);
+                      const outM = pricePerMillion(m.completionPrice);
+                      const price =
+                        inM !== undefined && outM !== undefined
+                          ? `$${inM.toFixed(2)}/$${outM.toFixed(2)}`
+                          : "";
+                      return (
+                        <button
+                          key={m.id}
+                          type="button"
+                          onClick={() => {
+                            setModel(m.id);
+                            setModelQuery("");
+                          }}
+                          title={
+                            (m.name ? m.name + " · " : "") +
+                            (price ? price + " per 1M (in/out)" : "price n/a") +
+                            (m.contextLength ? ` · ctx ${m.contextLength}` : "")
+                          }
+                          style={{
+                            display: "flex",
+                            width: "100%",
+                            alignItems: "center",
+                            justifyContent: "space-between",
+                            gap: 8,
+                            padding: "6px 9px",
+                            border: "none",
+                            borderBottom: "1px solid var(--border)",
+                            background: active ? "var(--accent-bg)" : "transparent",
+                            color: active ? "var(--accent)" : "var(--fg-muted)",
+                            cursor: "pointer",
+                            fontSize: 11.5,
+                            textAlign: "left",
+                          }}
+                        >
+                          <span className="mono" style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                            {star && <span style={{ color: "var(--accent)" }}>★ </span>}
+                            {m.id}
+                          </span>
+                          {price && (
+                            <span style={{ flexShrink: 0, fontSize: 10, color: "var(--fg-subtle)" }}>
+                              {price}
+                            </span>
+                          )}
+                        </button>
+                      );
+                    };
+                    return (
+                      <>
+                        {recommended.length > 0 && (
+                          <div style={{ padding: "4px 9px", fontSize: 9.5, fontWeight: 700, letterSpacing: "0.05em", color: "var(--fg-subtle)", background: "var(--bg-2)" }}>
+                            RECOMMENDED
+                          </div>
+                        )}
+                        {recommended.map((m) => row(m, true))}
+                        {rest.map((m) => row(m, false))}
+                        {filtered.length === 0 && (
+                          <div style={{ padding: "8px 9px", fontSize: 11.5, color: "var(--fg-subtle)" }}>
+                            No models match “{modelQuery}”.
+                          </div>
+                        )}
+                      </>
+                    );
+                  })()}
+                </div>
+              </div>
+            )}
+          </div>
 
           {/* API key */}
           <label style={{ display: "block", marginBottom: 8 }}>

--- a/src/lib/ai/__tests__/client.test.ts
+++ b/src/lib/ai/__tests__/client.test.ts
@@ -5,6 +5,11 @@ import {
   listModels,
   AiUpstreamError,
 } from "../client.js";
+import {
+  estimateTargetCostUSD,
+  pricePerMillion,
+  RECOMMENDED_MODEL_IDS,
+} from "../providers.js";
 
 function sseStream(frames: string[]): ReadableStream<Uint8Array> {
   const enc = new TextEncoder();
@@ -135,16 +140,21 @@ describe("ai/client chatCompletion (non-streaming)", () => {
 describe("ai/client listModels", () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it("parses, de-dupes and sorts model ids from /models", async () => {
+  it("parses, de-dupes and sorts models + pricing from /models", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(
         new Response(
           JSON.stringify({
             data: [
-              { id: "gpt-4o-mini" },
-              { id: "gpt-4o" },
-              { id: "gpt-4o-mini" },
+              {
+                id: "openai/gpt-4o-mini",
+                name: "GPT-4o mini",
+                context_length: 128000,
+                pricing: { prompt: "0.0000006", completion: "0.0000024" },
+              },
+              { id: "openai/gpt-4o" },
+              { id: "openai/gpt-4o-mini" },
               { not_an_id: true },
             ],
           }),
@@ -153,7 +163,12 @@ describe("ai/client listModels", () => {
       ),
     );
     const out = await listModels(cfg);
-    expect(out).toEqual(["gpt-4o", "gpt-4o-mini"]);
+    expect(out.map((m) => m.id)).toEqual(["openai/gpt-4o", "openai/gpt-4o-mini"]);
+    const mini = out.find((m) => m.id === "openai/gpt-4o-mini")!;
+    expect(mini.promptPrice).toBe(0.0000006);
+    expect(mini.completionPrice).toBe(0.0000024);
+    expect(mini.contextLength).toBe(128000);
+    expect(out.find((m) => m.id === "openai/gpt-4o")!.promptPrice).toBeUndefined();
   });
 
   it("hits the /models endpoint with the auth header when keyed", async () => {
@@ -173,5 +188,25 @@ describe("ai/client listModels", () => {
       vi.fn().mockResolvedValue(new Response("nope", { status: 401 })),
     );
     await expect(listModels(cfg)).rejects.toBeInstanceOf(AiUpstreamError);
+  });
+});
+
+describe("ai/providers cost estimate", () => {
+  it("estimates target cost from per-token prices", () => {
+    // 15 ops * (1500*p + 350*c)
+    const cost = estimateTargetCostUSD(0.0000006, 0.0000024)!;
+    // 15*(1500*6e-7 + 350*2.4e-6) = 15*(9e-4 + 8.4e-4) = 15*1.74e-3 = 0.0261
+    expect(cost).toBeCloseTo(0.0261, 4);
+  });
+  it("returns null when pricing is unknown (local providers)", () => {
+    expect(estimateTargetCostUSD(undefined, undefined)).toBeNull();
+    expect(estimateTargetCostUSD(0.0000006, undefined)).toBeNull();
+  });
+  it("pricePerMillion converts $/token to $/1M", () => {
+    expect(pricePerMillion(0.0000006)).toBeCloseTo(0.6, 6);
+    expect(pricePerMillion(undefined)).toBeUndefined();
+  });
+  it("has a non-empty recommended model list", () => {
+    expect(RECOMMENDED_MODEL_IDS.length).toBeGreaterThan(3);
   });
 });

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -137,14 +137,28 @@ export async function chatCompletion(
 }
 
 /**
- * List available model ids from an OpenAI-compatible `GET /models`. Used by the
- * settings UI to populate a model picker. OpenAI, OpenRouter, Ollama and
- * LM Studio all expose this. Returns the de-duped, sorted id list.
+ * One model from an OpenAI-compatible `/models` listing. OpenRouter also
+ * returns per-token `pricing` + `context_length`; OpenAI/Ollama omit pricing
+ * (fields stay undefined). Prices are USD per token (as OpenRouter reports).
+ */
+export interface ModelInfo {
+  id: string;
+  name?: string;
+  promptPrice?: number;
+  completionPrice?: number;
+  contextLength?: number;
+}
+
+/**
+ * List available models from an OpenAI-compatible `GET /models`. Used by the
+ * settings model picker. OpenAI, OpenRouter, Ollama and LM Studio all expose
+ * this; OpenRouter additionally carries pricing/context metadata which we
+ * surface for the price + cost-estimate UI. De-duped, sorted by id.
  */
 export async function listModels(
   cfg: StreamClientConfig,
   opts: { timeoutMs?: number; signal?: AbortSignal } = {},
-): Promise<string[]> {
+): Promise<ModelInfo[]> {
   const signal = combineSignals(opts.timeoutMs ?? 15_000, opts.signal);
   const headers: Record<string, string> = {};
   if (cfg.apiKey) headers["Authorization"] = `Bearer ${cfg.apiKey}`;
@@ -163,11 +177,36 @@ export async function listModels(
     }
     throw new AiUpstreamError(`Provider returned ${res.status}${detail ? `: ${detail}` : ""}`, res.status);
   }
-  const json = (await res.json()) as { data?: Array<{ id?: unknown }> };
-  const ids = (json?.data ?? [])
-    .map((m) => m?.id)
-    .filter((x): x is string => typeof x === "string" && x.length > 0);
-  return Array.from(new Set(ids)).sort();
+  const json = (await res.json()) as {
+    data?: Array<{
+      id?: unknown;
+      name?: unknown;
+      context_length?: unknown;
+      pricing?: { prompt?: unknown; completion?: unknown };
+    }>;
+  };
+  const num = (v: unknown): number | undefined => {
+    const n = Number(v);
+    return typeof v === "string" || typeof v === "number"
+      ? Number.isFinite(n)
+        ? n
+        : undefined
+      : undefined;
+  };
+  const seen = new Set<string>();
+  const out: ModelInfo[] = [];
+  for (const m of json?.data ?? []) {
+    if (typeof m?.id !== "string" || !m.id || seen.has(m.id)) continue;
+    seen.add(m.id);
+    out.push({
+      id: m.id,
+      name: typeof m.name === "string" ? m.name : undefined,
+      promptPrice: num(m.pricing?.prompt),
+      completionPrice: num(m.pricing?.completion),
+      contextLength: num(m.context_length),
+    });
+  }
+  return out.sort((a, b) => a.id.localeCompare(b.id));
 }
 
 /**

--- a/src/lib/ai/providers.ts
+++ b/src/lib/ai/providers.ts
@@ -44,6 +44,53 @@ export const AI_PROVIDERS: Record<AiProvider, ProviderPreset> = {
 
 export const AI_PROVIDER_ORDER: AiProvider[] = ["ollama", "openai", "openrouter"];
 
+/**
+ * Curated models that work well for recon-deck's explain/suggest tasks —
+ * cheap, strong instruction-following, reliable JSON. Surfaced as
+ * "Recommended" at the top of the picker when present in the provider list.
+ * (OpenRouter ids; a `:free` variant is included where one commonly exists.)
+ */
+export const RECOMMENDED_MODEL_IDS: string[] = [
+  "openai/gpt-4o-mini",
+  "anthropic/claude-3.5-haiku",
+  "google/gemini-2.0-flash-001",
+  "deepseek/deepseek-chat",
+  "meta-llama/llama-3.3-70b-instruct",
+  "qwen/qwen-2.5-72b-instruct",
+  "meta-llama/llama-3.3-70b-instruct:free",
+];
+
+/**
+ * Rough token budget for a "typical target" so we can show a ballpark spend.
+ * Deliberately conservative — a few ports, explain + suggest on each.
+ */
+export const COST_ESTIMATE = {
+  opsPerTarget: 15,
+  inTokensPerOp: 1500,
+  outTokensPerOp: 350,
+};
+
+/**
+ * Estimate USD to work a typical target with a model, given OpenRouter's
+ * per-token prices. Returns null when pricing is unknown (local providers).
+ */
+export function estimateTargetCostUSD(
+  promptPrice?: number,
+  completionPrice?: number,
+): number | null {
+  if (promptPrice === undefined || completionPrice === undefined) return null;
+  const { opsPerTarget, inTokensPerOp, outTokensPerOp } = COST_ESTIMATE;
+  return (
+    opsPerTarget *
+    (inTokensPerOp * promptPrice + outTokensPerOp * completionPrice)
+  );
+}
+
+/** Convert a $/token price to $/1M tokens for display. */
+export function pricePerMillion(perToken?: number): number | undefined {
+  return perToken === undefined ? undefined : perToken * 1_000_000;
+}
+
 export function isAiProvider(v: string): v is AiProvider {
   return v === "ollama" || v === "openai" || v === "openrouter";
 }


### PR DESCRIPTION
Rich model picker: search box, **Recommended** models pinned on top (★), per-model in/out $/1M inline + on hover (w/ context length), and a live **"≈ $X for a typical target"** cost estimate. Powered by OpenRouter's per-model pricing in `/models` (OpenAI/Ollama show no price). 562/562 tests, build OK. Targets develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)