### PR TITLE
feat(kb): version-gated conditionals on ftp/smb/ssh/mysql

### DIFF
--- a/knowledge/ports/21-ftp.yaml
+++ b/knowledge/ports/21-ftp.yaml
@@ -49,3 +49,17 @@ resources:
   - title: "FTP Default Credentials"
     url: "https://github.com/danielmiessler/SecLists/tree/master/Passwords/Default-Credentials"
     author: SecLists
+# Version-gated overlays — fired when nmap pins the exact server build.
+conditional:
+  - id: vsftpd-234-backdoor
+    when:
+      nmap_version_matches: { product: vsftpd, version: "2.3.4" }
+    adds_checks:
+      - key: ftp-vsftpd-234-backdoor
+        label: "Triggered the vsftpd 2.3.4 backdoor — a USER ending in :) opens a bind shell on tcp/6200 (CVE-2011-2523)"
+  - id: proftpd-modcopy-rce
+    when:
+      nmap_version_matches: { product: ProFTPD, version: "1.3.5" }
+    adds_checks:
+      - key: ftp-proftpd-modcopy-rce
+        label: "Tested ProFTPD mod_copy RCE via SITE CPFR/CPTO to write a webshell (CVE-2015-3306)"

--- a/knowledge/ports/22-ssh.yaml
+++ b/knowledge/ports/22-ssh.yaml
@@ -46,3 +46,18 @@ resources:
   - title: "SSH Default Credentials"
     url: "https://github.com/danielmiessler/SecLists/tree/master/Passwords/Default-Credentials"
     author: SecLists
+# Version-gated OpenSSH overlays. The banner's `pN` portable suffix is parsed
+# down to its leading digit, so these minor-version ranges bracket correctly.
+conditional:
+  - id: openssh-username-enum
+    when:
+      nmap_version_matches: { product: OpenSSH, version: "< 7.7" }
+    adds_checks:
+      - key: ssh-openssh-username-enum
+        label: "Ran username enumeration against OpenSSH < 7.7 via auth_request timing (CVE-2018-15473)"
+  - id: openssh-regresshion
+    when:
+      nmap_version_matches: { product: OpenSSH, version: ">= 8.5 < 9.8" }
+    adds_checks:
+      - key: ssh-openssh-regresshion
+        label: "Assessed OpenSSH 8.5–9.7 for the regreSSHion pre-auth RCE (CVE-2024-6387)"

--- a/knowledge/ports/3306-mysql.yaml
+++ b/knowledge/ports/3306-mysql.yaml
@@ -46,3 +46,11 @@ resources:
   - title: "MySQL Default Credentials"
     url: "https://github.com/danielmiessler/SecLists/tree/master/Passwords/Default-Credentials"
     author: SecLists
+# Version-gated overlay for the classic MySQL 5.5 auth bypass.
+conditional:
+  - id: mysql-cve-2012-2122
+    when:
+      nmap_version_matches: { product: MySQL, version: ">= 5.1.0 < 5.5.24" }
+    adds_checks:
+      - key: mysql-auth-bypass-2122
+        label: "Tested the memcmp() auth bypass — repeating the login with a wrong password (~300×) eventually authenticates (CVE-2012-2122)"

--- a/knowledge/ports/445-smb.yaml
+++ b/knowledge/ports/445-smb.yaml
@@ -37,6 +37,7 @@ commands:
   - label: "Enumerate shares (null session)"
     template: "smbclient -L //{IP}/ -N"
   - label: "nmap SMB scripts"
+    id: smb-nmap
     template: "nmap -p{PORT} --script=smb-os-discovery,smb-enum-shares,smb-enum-users,smb-vuln-ms17-010 {IP}"
   - label: "enum4linux-ng"
     template: "enum4linux-ng -A {IP}"
@@ -89,3 +90,21 @@ resources:
   - title: "NetBIOS / SMB Cheatsheet"
     url: "https://hacktricks.wiki/en/network-services-pentesting/137-138-139-pentesting-netbios.html"
     author: HackTricks
+# Version-gated Samba RCE overlays. nmap emits product "Samba smbd" so the
+# `Samba` substring matches; the version ranges bracket the affected builds.
+conditional:
+  - id: samba-usermap-rce
+    when:
+      nmap_version_matches: { product: Samba, version: ">= 3.0.0 < 3.0.26" }
+    adds_checks:
+      - key: smb-samba-usermap-rce
+        label: "Exploited Samba 'username map script' command injection — unauthenticated RCE via a crafted username (CVE-2007-2447)"
+  - id: sambacry-rce
+    when:
+      nmap_version_matches: { product: Samba, version: ">= 3.5.0 < 4.6.4" }
+    adds_checks:
+      - key: smb-sambacry-rce
+        label: "Tested SambaCry / EternalRed — RCE by loading a shared object from a writable share (CVE-2017-7494)"
+    modifies_commands:
+      smb-nmap:
+        append: ",smb-vuln-cve-2017-7494"

--- a/src/lib/kb/__tests__/version-conditionals.test.ts
+++ b/src/lib/kb/__tests__/version-conditionals.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import yaml from "js-yaml";
+import { KbEntrySchema, type KbEntry } from "../schema.js";
+import { applyConditionals, type ResolveContext } from "../resolve.js";
+
+/**
+ * Version-gated KB conditionals (beta.7): nmap_version_matches overlays on
+ * FTP / SMB / SSH / MySQL. These ride on the compareVersions fix that reduces
+ * each segment to its leading integer, so an OpenSSH `pN` suffix no longer
+ * collapses the minor version to 0 — without it the SSH ranges below would
+ * mis-fire. Loading the real shipped YAML keeps the overlays honest.
+ */
+
+const PORTS_DIR = path.resolve(__dirname, "../../../../knowledge/ports");
+
+function loadEntry(file: string): KbEntry {
+  const doc = yaml.load(fs.readFileSync(path.join(PORTS_DIR, file), "utf8"));
+  return KbEntrySchema.parse(doc);
+}
+
+function ctx(
+  product: string | null,
+  version: string | null,
+  service = "x",
+): ResolveContext {
+  return {
+    port: { service, product, version },
+    scripts: [],
+    fingerprints: [],
+  };
+}
+
+describe("version conditionals — 21 ftp", () => {
+  const entry = loadEntry("21-ftp.yaml");
+
+  it("vsftpd 2.3.4 → backdoor check fires", () => {
+    const r = applyConditionals(entry, ctx("vsftpd", "2.3.4", "ftp"));
+    expect(r.active).toEqual([{ id: "vsftpd-234-backdoor" }]);
+    expect(r.checks.some((c) => c.key === "ftp-vsftpd-234-backdoor")).toBe(true);
+  });
+
+  it("vsftpd 3.0.3 → nothing fires", () => {
+    const r = applyConditionals(entry, ctx("vsftpd", "3.0.3", "ftp"));
+    expect(r.active).toEqual([]);
+  });
+
+  it("ProFTPD 1.3.5 → mod_copy check fires", () => {
+    const r = applyConditionals(entry, ctx("ProFTPD", "1.3.5", "ftp"));
+    expect(r.active).toEqual([{ id: "proftpd-modcopy-rce" }]);
+  });
+});
+
+describe("version conditionals — 445 smb", () => {
+  const entry = loadEntry("445-smb.yaml");
+
+  it("Samba smbd 3.0.20 → usermap RCE (not SambaCry)", () => {
+    const r = applyConditionals(entry, ctx("Samba smbd", "3.0.20", "smb"));
+    expect(r.active).toEqual([{ id: "samba-usermap-rce" }]);
+  });
+
+  it("Samba smbd 4.5.16 → SambaCry + nmap script appended", () => {
+    const r = applyConditionals(entry, ctx("Samba smbd", "4.5.16", "smb"));
+    expect(r.active).toEqual([{ id: "sambacry-rce" }]);
+    const nmap = r.commands.find((c) => c.id === "smb-nmap");
+    expect(nmap?.template).toContain(",smb-vuln-cve-2017-7494");
+    expect(nmap?.appendedBy).toEqual(["sambacry-rce"]);
+  });
+
+  it("Samba smbd 4.16.0 → neither (patched range)", () => {
+    const r = applyConditionals(entry, ctx("Samba smbd", "4.16.0", "smb"));
+    expect(r.active).toEqual([]);
+  });
+});
+
+describe("version conditionals — 22 ssh (pN suffix handling)", () => {
+  const entry = loadEntry("22-ssh.yaml");
+
+  it("OpenSSH 7.6p1 → username enum (< 7.7)", () => {
+    const r = applyConditionals(entry, ctx("OpenSSH", "7.6p1", "ssh"));
+    expect(r.active).toEqual([{ id: "openssh-username-enum" }]);
+  });
+
+  it("OpenSSH 7.7p1 → nothing (suffix must not collapse 7.7 to 7.0)", () => {
+    const r = applyConditionals(entry, ctx("OpenSSH", "7.7p1", "ssh"));
+    expect(r.active).toEqual([]);
+  });
+
+  it("OpenSSH 9.6p1 → regreSSHion (>= 8.5 < 9.8)", () => {
+    const r = applyConditionals(entry, ctx("OpenSSH", "9.6p1", "ssh"));
+    expect(r.active).toEqual([{ id: "openssh-regresshion" }]);
+  });
+
+  it("OpenSSH 9.8p1 → nothing (fixed in 9.8)", () => {
+    const r = applyConditionals(entry, ctx("OpenSSH", "9.8p1", "ssh"));
+    expect(r.active).toEqual([]);
+  });
+
+  it("real-world banner with distro suffix still brackets correctly", () => {
+    const r = applyConditionals(
+      entry,
+      ctx("OpenSSH", "7.6p1 Ubuntu 4ubuntu0.3", "ssh"),
+    );
+    expect(r.active).toEqual([{ id: "openssh-username-enum" }]);
+  });
+});
+
+describe("version conditionals — 3306 mysql", () => {
+  const entry = loadEntry("3306-mysql.yaml");
+
+  it("MySQL 5.5.23 → auth bypass check fires", () => {
+    const r = applyConditionals(entry, ctx("MySQL", "5.5.23", "mysql"));
+    expect(r.active).toEqual([{ id: "mysql-cve-2012-2122" }]);
+  });
+
+  it("MySQL 5.5.24 → nothing (patched boundary)", () => {
+    const r = applyConditionals(entry, ctx("MySQL", "5.5.24", "mysql"));
+    expect(r.active).toEqual([]);
+  });
+
+  it("MySQL 8.0.32 → nothing", () => {
+    const r = applyConditionals(entry, ctx("MySQL", "8.0.32", "mysql"));
+    expect(r.active).toEqual([]);
+  });
+});

--- a/src/lib/kb/resolve.ts
+++ b/src/lib/kb/resolve.ts
@@ -110,13 +110,16 @@ export interface ResolvedEntry {
 
 /**
  * Compare two dotted-numeric versions. Returns -1 / 0 / 1 like a usual
- * comparator. Non-numeric segments are coerced to 0 so an exotic build
- * suffix doesn't poison the comparison; KB authors who need exotic
- * matching should use a different predicate.
+ * comparator. Each segment is reduced to its leading integer, so a build
+ * suffix attached to a number is preserved at that position rather than
+ * zeroed — `"7.7p1"` parses as `[7, 7]`, not `[7, 0]`. This matters for
+ * services whose banner always carries a portable suffix (OpenSSH `pN`,
+ * Samba/MySQL distro tags). A segment with no leading digit (e.g. a bare
+ * "Ubuntu" token from a multi-word banner) still collapses to 0.
  */
 function compareVersions(a: string, b: string): number {
-  const pa = a.replace(/^v/i, "").split(/[.\s]/).map((n) => Number(n) || 0);
-  const pb = b.replace(/^v/i, "").split(/[.\s]/).map((n) => Number(n) || 0);
+  const pa = a.replace(/^v/i, "").split(/[.\s]/).map((n) => parseInt(n, 10) || 0);
+  const pb = b.replace(/^v/i, "").split(/[.\s]/).map((n) => parseInt(n, 10) || 0);
   const len = Math.max(pa.length, pb.length);
   for (let i = 0; i < len; i++) {
     const da = pa[i] ?? 0;


### PR DESCRIPTION
## What

beta.7 content. Follows the web overlays (#55) with the conditional system's **other** predicate — `nmap_version_matches` — to flag build-specific vulnerabilities the moment nmap pins the version.

| Port | Overlay | CVE | Range |
|---|---|---|---|
| 21-ftp | vsftpd 2.3.4 backdoor | CVE-2011-2523 | `2.3.4` |
| 21-ftp | ProFTPD mod_copy RCE | CVE-2015-3306 | `1.3.5` |
| 445-smb | Samba `usermap_script` RCE | CVE-2007-2447 | `3.0.0 ≤ v < 3.0.26` |
| 445-smb | SambaCry / EternalRed | CVE-2017-7494 | `3.5.0 ≤ v < 4.6.4` |
| 22-ssh | OpenSSH username enum | CVE-2018-15473 | `< 7.7` |
| 22-ssh | regreSSHion pre-auth RCE | CVE-2024-6387 | `8.5 ≤ v < 9.8` |
| 3306-mysql | memcmp() auth bypass | CVE-2012-2122 | `5.1.0 ≤ v < 5.5.24` |

SambaCry also appends `smb-vuln-cve-2017-7494` to the nmap SMB scan (`modifies_commands`).

## Version-parser fix (required for SSH)

`compareVersions` reduced any non-numeric segment to `0`, so OpenSSH `"7.7p1"` parsed as `[7, 0]` — and `"< 7.7"` mis-fired on 7.7 / 7.8 / 7.9. It now reduces each segment to its **leading integer** (`parseInt`), so `"7.7p1"` → `[7, 7]` and the SSH ranges bracket correctly. Pure-numeric versions are unchanged; a bare non-numeric token (multi-word banner) still collapses to 0.

## Verification

- `version-conditionals.test.ts` (new) covers the `pN`-suffix handling and asserts every overlay fires **and stays inert off-range** against the **real shipped KB** (incl. a real-world `"7.6p1 Ubuntu 4ubuntu0.3"` banner)
- `lint:kb` passes · `tsc` clean · **583/583** tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)