### PR TITLE
feat(paste): "which nmap scan should I paste?" helper

### DIFF
--- a/src/components/PastePanel.tsx
+++ b/src/components/PastePanel.tsx
@@ -13,11 +13,13 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { Check, ChevronDown, ChevronRight, Copy, HelpCircle } from "lucide-react";
 
 export function PastePanel() {
   const [input, setInput] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
   const router = useRouter();
 
   async function handleSubmit() {
@@ -152,6 +154,11 @@ PORT     STATE SERVICE     VERSION
         />
       </div>
 
+      {/* How-to disclosure — nudges the operator to run a version+script scan
+          so the heatmap risk and the stack/version conditional overlays have
+          data to work with, then paste that output back here. */}
+      <HowToScan open={showHelp} onToggle={() => setShowHelp((v) => !v)} />
+
       {/* Action row */}
       <div className="mt-[14px] flex items-center gap-3">
         <button
@@ -205,6 +212,179 @@ PORT     STATE SERVICE     VERSION
           {error}
         </p>
       )}
+    </div>
+  );
+}
+
+/**
+ * Collapsible "how to scan" helper. Recommends the nmap invocation that gives
+ * recon-deck the most to work with — `-sV` version banners feed the version
+ * conditionals (vsftpd/Samba/OpenSSH CVEs) and `-sC` default scripts feed the
+ * stack conditionals (PHP/WordPress/Tomcat…), while `-oN` gives clean text to
+ * paste back. The point is to turn a bare port list into a fingerprinted scan.
+ */
+function HowToScan({
+  open,
+  onToggle,
+}: {
+  open: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="mt-[10px]">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="inline-flex items-center gap-1.5"
+        style={{
+          padding: "4px 6px",
+          marginLeft: -6,
+          background: "transparent",
+          border: 0,
+          color: "var(--fg-subtle)",
+          fontSize: 12,
+          cursor: "pointer",
+        }}
+        aria-expanded={open}
+      >
+        <HelpCircle size={13} />
+        <span>Which nmap scan should I paste?</span>
+        {open ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+      </button>
+
+      {open && (
+        <div
+          className="mt-2"
+          style={{
+            padding: 14,
+            borderRadius: 6,
+            background: "var(--bg-1)",
+            border: "1px solid var(--border)",
+          }}
+        >
+          <p
+            style={{
+              fontSize: 12.5,
+              color: "var(--fg-muted)",
+              margin: "0 0 12px",
+              lineHeight: 1.6,
+            }}
+          >
+            recon-deck reads a bare port list, but it does far more with a{" "}
+            <span style={{ color: "var(--fg)" }}>versioned, scripted</span> scan:
+            service versions unlock CVE-specific steps (vsftpd 2.3.4, Samba
+            usermap, OpenSSH…) and default-script output lets it auto-detect the
+            web stack and tailor the checklist. Run one of these, then paste the
+            output here.
+          </p>
+
+          <CommandRow
+            label="Full — all ports, versions + default scripts (recommended)"
+            command="nmap -sCV -p- --min-rate 1000 -oN nmap.txt <TARGET>"
+          />
+          <CommandRow
+            label="Fast — top 1000 ports, same depth"
+            command="nmap -sCV --top-ports 1000 -oN nmap.txt <TARGET>"
+          />
+
+          <p
+            style={{
+              fontSize: 11.5,
+              color: "var(--fg-subtle)",
+              margin: "10px 0 0",
+              lineHeight: 1.55,
+            }}
+          >
+            Paste the contents of{" "}
+            <span className="mono" style={{ color: "var(--fg-muted)" }}>
+              nmap.txt
+            </span>{" "}
+            above — or scan with{" "}
+            <span className="mono" style={{ color: "var(--fg-muted)" }}>
+              -oX nmap.xml
+            </span>{" "}
+            and paste the XML. Even richer: drop an AutoRecon results{" "}
+            <span className="mono" style={{ color: "var(--fg-muted)" }}>
+              .zip
+            </span>{" "}
+            on the Import panel.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CommandRow({
+  label,
+  command,
+}: {
+  label: string;
+  command: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard blocked — the command is selectable in the field regardless */
+    }
+  }
+
+  return (
+    <div className="mt-2 first:mt-0">
+      <div
+        style={{
+          fontSize: 11,
+          color: "var(--fg-subtle)",
+          marginBottom: 4,
+        }}
+      >
+        {label}
+      </div>
+      <div
+        className="flex items-center gap-2"
+        style={{
+          padding: "7px 8px 7px 12px",
+          borderRadius: 5,
+          background: "var(--code, var(--bg-2))",
+          border: "1px solid var(--border)",
+        }}
+      >
+        <code
+          className="mono"
+          style={{
+            flex: 1,
+            fontSize: 12,
+            color: "var(--fg)",
+            overflowX: "auto",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {command}
+        </code>
+        <button
+          type="button"
+          onClick={copy}
+          aria-label="Copy command"
+          className="inline-flex items-center gap-1 shrink-0"
+          style={{
+            padding: "3px 8px",
+            borderRadius: 4,
+            background: "var(--bg-2)",
+            border: "1px solid var(--border)",
+            color: copied ? "var(--accent)" : "var(--fg-muted)",
+            fontSize: 11,
+            cursor: "pointer",
+          }}
+        >
+          {copied ? <Check size={12} /> : <Copy size={12} />}
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What

The paste panel accepted a bare port list but never told operators that a **richer scan unlocks far more** — and the new stack/version conditionals (#55, #56) are dead weight without version banners + script output to fire on.

Adds a collapsible helper under the paste field — **"Which nmap scan should I paste?"** — that recommends the scan recon-deck gets the most from and nudges the operator to run it and paste the result back:

- `nmap -sCV -p- --min-rate 1000 -oN nmap.txt <TARGET>` — full (recommended)
- `nmap -sCV --top-ports 1000 -oN nmap.txt <TARGET>` — fast

Each command has a one-click **copy** button. The copy explains *why* it matters:
- `-sV` versions → CVE-specific overlays (vsftpd / Samba / OpenSSH…)
- `-sC` default scripts → web-stack overlays (PHP / WordPress / Tomcat…)
- `-oN` → clean text to paste

Also points at `-oX` XML and the AutoRecon `.zip` import as alternatives.

## Why

Closes the loop on the conditional KB work: the overlays only fire on fingerprinted scans, so the paste surface now actively steers operators toward producing one.

## Verification

- `tsc` clean · `eslint` clean · `next build` compiles · **583/583** tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)