### PR TITLE
feat(wordlists): encourage SecLists install when missing

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -26,6 +26,7 @@ import { EditorIntegrationToggle } from "@/components/EditorIntegrationToggle";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { OnboardingSettingsSection } from "@/components/OnboardingSettingsSection";
 import { detectToolPaths } from "@/lib/tool-paths";
+import { CopyCommand, SECLISTS_INSTALL } from "@/components/CopyCommand";
 import pkg from "../../../package.json";
 
 export const dynamic = "force-dynamic";
@@ -149,6 +150,62 @@ export default function SettingsIndexPage() {
               and the rows below will populate.
             </div>
           )}
+        {!tools.seclists && (
+          <div
+            style={{
+              marginBottom: 12,
+              padding: "12px 14px",
+              borderRadius: 6,
+              border: "1px solid var(--accent-border)",
+              background: "var(--accent-bg)",
+            }}
+          >
+            <div
+              style={{
+                fontSize: 11,
+                textTransform: "uppercase",
+                letterSpacing: "0.06em",
+                color: "var(--fg-subtle)",
+                marginBottom: 6,
+              }}
+            >
+              SecLists not detected
+            </div>
+            <p
+              style={{
+                fontSize: 12.5,
+                color: "var(--fg-muted)",
+                margin: "0 0 4px",
+                lineHeight: 1.55,
+              }}
+            >
+              Many KB commands (gobuster, ffuf, smtp-user-enum…) point at
+              SecLists. Install it on the box where you run those commands:
+            </p>
+            <CopyCommand label="Kali / Debian" command={SECLISTS_INSTALL.apt} />
+            <CopyCommand label="Any OS — git clone" command={SECLISTS_INSTALL.git} />
+            <p
+              style={{
+                fontSize: 11.5,
+                color: "var(--fg-subtle)",
+                margin: "10px 0 0",
+                lineHeight: 1.5,
+              }}
+            >
+              {tools.inDocker
+                ? "Running in Docker: install on the host and bind-mount it (-v /usr/share/wordlists:/host/wordlists:ro), or "
+                : "Installed somewhere non-standard? "}
+              point individual paths at it under{" "}
+              <Link
+                href="/settings/wordlists"
+                style={{ color: "var(--accent)", textDecoration: "underline" }}
+              >
+                Wordlists
+              </Link>
+              .
+            </p>
+          </div>
+        )}
         <div
           className="grid grid-cols-1 gap-2"
           style={{ fontSize: 12.5 }}

--- a/app/welcome/_components/PathsStep.tsx
+++ b/app/welcome/_components/PathsStep.tsx
@@ -11,6 +11,7 @@
 import { useState } from "react";
 import { Check, Loader2 } from "lucide-react";
 import { validatePath } from "../_actions";
+import { CopyCommand, SECLISTS_INSTALL } from "@/components/CopyCommand";
 import type { OnboardingForm } from "./WelcomeFlow";
 
 type Status = "ok" | "miss" | "empty" | "checking";
@@ -123,6 +124,21 @@ export function PathsStep({
               onBlur={(v) => handleBlur(f.key, v)}
             />
           ))}
+        </div>
+
+        <div style={{ marginTop: 18, maxWidth: 560 }}>
+          <div
+            style={{
+              fontSize: 11.5,
+              color: "var(--fg-muted)",
+              lineHeight: 1.55,
+              marginBottom: 2,
+            }}
+          >
+            Don&apos;t have SecLists yet? recon-deck&apos;s gobuster/ffuf
+            commands rely on it — install it on your attack box:
+          </div>
+          <CopyCommand command={SECLISTS_INSTALL.apt} />
         </div>
       </div>
 

--- a/src/components/CopyCommand.tsx
+++ b/src/components/CopyCommand.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+/**
+ * CopyCommand — a single shell command in a mono pill with a one-click copy
+ * button. Shared by the paste "how to scan" helper, the onboarding wordlist
+ * step, and the Settings SecLists-install nudge so the copy affordance looks
+ * and behaves the same everywhere.
+ */
+
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+export function CopyCommand({
+  command,
+  label,
+}: {
+  command: string;
+  /** Optional caption rendered above the command. */
+  label?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard blocked — the command is still selectable in the field */
+    }
+  }
+
+  return (
+    <div className="mt-2 first:mt-0">
+      {label && (
+        <div style={{ fontSize: 11, color: "var(--fg-subtle)", marginBottom: 4 }}>
+          {label}
+        </div>
+      )}
+      <div
+        className="flex items-center gap-2"
+        style={{
+          padding: "7px 8px 7px 12px",
+          borderRadius: 5,
+          background: "var(--code, var(--bg-2))",
+          border: "1px solid var(--border)",
+        }}
+      >
+        <code
+          className="mono"
+          style={{
+            flex: 1,
+            fontSize: 12,
+            color: "var(--fg)",
+            overflowX: "auto",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {command}
+        </code>
+        <button
+          type="button"
+          onClick={copy}
+          aria-label="Copy command"
+          className="inline-flex items-center gap-1 shrink-0"
+          style={{
+            padding: "3px 8px",
+            borderRadius: 4,
+            background: "var(--bg-2)",
+            border: "1px solid var(--border)",
+            color: copied ? "var(--accent)" : "var(--fg-muted)",
+            fontSize: 11,
+            cursor: "pointer",
+          }}
+        >
+          {copied ? <Check size={12} /> : <Copy size={12} />}
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** The two canonical ways to install SecLists, reused by every nudge. */
+export const SECLISTS_INSTALL = {
+  apt: "sudo apt install seclists",
+  git: "git clone https://github.com/danielmiessler/SecLists /usr/share/seclists",
+} as const;

--- a/src/components/PastePanel.tsx
+++ b/src/components/PastePanel.tsx
@@ -13,7 +13,8 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Check, ChevronDown, ChevronRight, Copy, HelpCircle } from "lucide-react";
+import { ChevronDown, ChevronRight, HelpCircle } from "lucide-react";
+import { CopyCommand, SECLISTS_INSTALL } from "@/components/CopyCommand";
 
 export function PastePanel() {
   const [input, setInput] = useState("");
@@ -278,11 +279,11 @@ function HowToScan({
             output here.
           </p>
 
-          <CommandRow
+          <CopyCommand
             label="Full — all ports, versions + default scripts (recommended)"
             command="nmap -sCV -p- --min-rate 1000 -oN nmap.txt <TARGET>"
           />
-          <CommandRow
+          <CopyCommand
             label="Fast — top 1000 ports, same depth"
             command="nmap -sCV --top-ports 1000 -oN nmap.txt <TARGET>"
           />
@@ -309,82 +310,23 @@ function HowToScan({
             </span>{" "}
             on the Import panel.
           </p>
+
+          <p
+            style={{
+              fontSize: 11.5,
+              color: "var(--fg-subtle)",
+              margin: "12px 0 0",
+              lineHeight: 1.55,
+            }}
+          >
+            The <span className="mono" style={{ color: "var(--fg-muted)" }}>ffuf</span>/
+            <span className="mono" style={{ color: "var(--fg-muted)" }}>gobuster</span>{" "}
+            commands recon-deck suggests use SecLists. Don&apos;t have it on your
+            box?
+          </p>
+          <CopyCommand command={SECLISTS_INSTALL.apt} />
         </div>
       )}
-    </div>
-  );
-}
-
-function CommandRow({
-  label,
-  command,
-}: {
-  label: string;
-  command: string;
-}) {
-  const [copied, setCopied] = useState(false);
-
-  async function copy() {
-    try {
-      await navigator.clipboard.writeText(command);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1500);
-    } catch {
-      /* clipboard blocked — the command is selectable in the field regardless */
-    }
-  }
-
-  return (
-    <div className="mt-2 first:mt-0">
-      <div
-        style={{
-          fontSize: 11,
-          color: "var(--fg-subtle)",
-          marginBottom: 4,
-        }}
-      >
-        {label}
-      </div>
-      <div
-        className="flex items-center gap-2"
-        style={{
-          padding: "7px 8px 7px 12px",
-          borderRadius: 5,
-          background: "var(--code, var(--bg-2))",
-          border: "1px solid var(--border)",
-        }}
-      >
-        <code
-          className="mono"
-          style={{
-            flex: 1,
-            fontSize: 12,
-            color: "var(--fg)",
-            overflowX: "auto",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {command}
-        </code>
-        <button
-          type="button"
-          onClick={copy}
-          aria-label="Copy command"
-          className="inline-flex items-center gap-1 shrink-0"
-          style={{
-            padding: "3px 8px",
-            borderRadius: 4,
-            background: "var(--bg-2)",
-            border: "1px solid var(--border)",
-            color: copied ? "var(--accent)" : "var(--fg-muted)",
-            fontSize: 11,
-            cursor: "pointer",
-          }}
-        >
-          {copied ? <Check size={12} /> : <Copy size={12} />}
-          {copied ? "Copied" : "Copy"}
-        </button>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What

recon-deck's gobuster/ffuf/smtp-user-enum commands point at SecLists, but nothing told operators to install it — a fresh box just gets **"wordlist not found"** when running the copied command. Surface a concrete, copyable install nudge in the three places it matters:

- **Settings → Detected tools** — a callout shown **only when SecLists isn't detected**, with `sudo apt install seclists` + `git clone …` and a pointer to the Docker bind-mount / Wordlists override for non-standard installs.
- **Onboarding (Local paths step)** — a hint beside the wordlist field nudging first-run operators to install it on their attack box.
- **Paste panel "how to scan" helper** — a one-liner under the scan commands.

## Shared piece

Extracts a `CopyCommand` client component (command pill + one-click copy) reused by all three surfaces **and** the existing paste scan-command helper, plus a `SECLISTS_INSTALL` constant so the install commands live in one place.

## Context

The app runs in Docker (OS-agnostic), but the commands it emits are Linux/Kali-flavored and run on the operator's attack box. SecLists detection (`tool-paths.ts`) already probes common locations; this PR turns a missing result into actionable guidance instead of a bare "Not found".

## Verification

- `tsc` clean · `eslint` clean · `next build` compiles · **583/583** tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)