### PR TITLE
fix: installer sh-compat + port override + real version (health/welcome)

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -13,10 +13,10 @@
  * Note: route handlers run server-side by default — no `import "server-only"`
  * directive needed (only `src/lib/**` modules use that guard).
  *
- * `version` provenance: `npm_package_version` is normally set by `npm start`,
- * NOT by raw `node server.js`. Inside the production container we fall back to
- * "unknown" — harmless for liveness; CI smoke tests only assert `ok: true`.
- * (Assumption A8 in 08-RESEARCH.md.)
+ * `version` provenance: `APP_VERSION` is inlined from package.json at build
+ * time via next.config (`env`), so it's correct inside the container where
+ * `node server.js` would otherwise leave `npm_package_version` unset. The
+ * remaining fallbacks keep dev/CI sane.
  */
 
 import { NextResponse } from "next/server";
@@ -29,7 +29,8 @@ export const dynamic = "force-dynamic";
 export async function GET() {
   return NextResponse.json({
     ok: true,
-    version: process.env.npm_package_version ?? "unknown",
+    version:
+      process.env.APP_VERSION ?? process.env.npm_package_version ?? "unknown",
     ts: new Date().toISOString(),
   });
 }

--- a/app/welcome/_components/BootTerminal.tsx
+++ b/app/welcome/_components/BootTerminal.tsx
@@ -17,9 +17,13 @@ interface Line {
   style: "cmd" | "info" | "ok" | "warn" | "ready";
 }
 
+// Inlined from package.json at build time via next.config `env`. Falls back to
+// "dev" under `npm run dev`, where the build constant isn't substituted.
+const APP_VERSION = process.env.APP_VERSION ?? "dev";
+
 const BOOT_LINES: Line[] = [
   { glyph: "$", text: "rd init", style: "cmd" },
-  { glyph: "→", text: "loading recon-deck v2.0.1", style: "info" },
+  { glyph: "→", text: `loading recon-deck v${APP_VERSION}`, style: "info" },
   { glyph: "✓", text: "local sqlite · /data/recon.db", style: "ok" },
   { glyph: "✓", text: "knowledge base · 33 entries loaded", style: "ok" },
   { glyph: "✓", text: "kb editor · /knowledge/*.yaml", style: "ok" },

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # recon-deck — one-liner Docker installer.
 #
@@ -16,12 +16,16 @@
 #   3. Creates persistent named volumes for the SQLite DB + user KB.
 #   4. Runs the container detached on 127.0.0.1:13337 (loopback only — solo
 #      pentest tool, never exposed to LAN by default). Port 13337 was picked
-#      to dodge the dev-server crowd that lives on 3000/8080.
+#      to dodge the dev-server crowd that lives on 3000/8080. Override with
+#      RECON_DECK_PORT=13338 if 13337 is taken.
 #   5. Tries to open the browser (Linux: xdg-open, macOS: open).
 #
 # To uninstall: `docker rm -f recon-deck && docker volume rm recondeck-data recondeck-kb`.
 
-set -euo pipefail
+# POSIX sh — no bashisms — so the documented `curl ... | sh` works under dash
+# (Debian/Ubuntu /bin/sh). `pipefail` is bash-only and would abort dash with
+# "Illegal option -o pipefail" the moment the script is piped to sh.
+set -eu
 
 # Channel selection — default stable (:latest), opt into pre-releases with --beta.
 CHANNEL_TAG="latest"
@@ -42,7 +46,9 @@ done
 
 IMAGE="ghcr.io/kocaemre/recon-deck:${CHANNEL_TAG}"
 CONTAINER_NAME="recon-deck"
-PORT="13337"
+# Host port — override with RECON_DECK_PORT if 13337 is already taken. The
+# container always listens on 13337 internally; only the host side moves.
+PORT="${RECON_DECK_PORT:-13337}"
 URL="http://localhost:${PORT}"
 
 # 1. Pre-flight — docker reachable?
@@ -86,15 +92,35 @@ if docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
   docker rm -f "$CONTAINER_NAME" >/dev/null
 fi
 
-# 4. Run.
-docker run -d \
+# 4. Run. Capture stderr (stdout = container id, discarded) so a port clash
+#    gives an actionable hint instead of a raw docker traceback.
+run_failed=0
+run_err="$(docker run -d \
   --name "$CONTAINER_NAME" \
   --restart unless-stopped \
   -p "127.0.0.1:${PORT}:13337" \
   -v recondeck-data:/data \
   -v recondeck-kb:/kb \
   -e HOSTNAME=0.0.0.0 \
-  "$IMAGE" >/dev/null
+  "$IMAGE" 2>&1 >/dev/null)" || run_failed=1
+
+if [ "$run_failed" -ne 0 ]; then
+  # A failed run can leave a "Created" container holding the name — clear it so
+  # a re-run with a different port isn't blocked by the stale name.
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  case "$run_err" in
+    *"already allocated"* | *"address already in use"* | *"port is already"*)
+      printf 'Port %s is already in use.\n' "$PORT" >&2
+      printf 'Re-run on a different port, e.g.:\n' >&2
+      printf '  RECON_DECK_PORT=13338 curl -sSL https://raw.githubusercontent.com/kocaemre/recon-deck/main/install.sh | sh -s -- --beta\n' >&2
+      printf 'Or find what holds it:  docker ps --filter "publish=%s"\n' "$PORT" >&2
+      ;;
+    *)
+      printf 'docker run failed:\n%s\n' "$run_err" >&2
+      ;;
+  esac
+  exit 1
+fi
 
 printf '\nrecon-deck is up at %s\n' "$URL"
 printf 'Stop  : docker stop %s\n' "$CONTAINER_NAME"

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,14 @@
 // supports this), but that requires per-request nonce generation and propagation
 // through the RSC render tree. Deferred to a future hardening phase.
 import bundleAnalyzer from "@next/bundle-analyzer";
+import { createRequire } from "node:module";
+
+// Single source of truth for the app version: package.json (bumped per release,
+// committed before the image builds). Inlined into both server + client bundles
+// via `env` below so the health endpoint and UI report the real version instead
+// of relying on npm_package_version, which `node server.js` doesn't set.
+const require = createRequire(import.meta.url);
+const { version: appVersion } = require("./package.json");
 
 const isDev = process.env.NODE_ENV === "development";
 const cspHeader = [
@@ -26,6 +34,11 @@ const cspHeader = [
 const nextConfig = {
   output: "standalone",
   serverExternalPackages: ["better-sqlite3"],
+  // Build-time constant — available as process.env.APP_VERSION in server route
+  // handlers and client components alike.
+  env: {
+    APP_VERSION: appVersion,
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
Four issues surfaced from the **beta installer image** QA pass (thanks @Hermes):

## 1. Installer aborted under `sh` (critical)
`install.sh` shipped `set -euo pipefail`, but the docs pipe it to `sh` (dash on Debian/Ubuntu) — which dies with `set: Illegal option -o pipefail` before doing anything:

```
$ curl -fsSL …/install.sh | sh -s -- --help
sh: 24: set: Illegal option -o pipefail
```

The script had **no other bashisms** (verified), so it's now POSIX: `#!/bin/sh` + `set -eu`. The documented `curl … | sh -s -- --beta` works as-is — no docs change needed. Validated with `sh -n`, `dash -n`, and `sh install.sh --help` (exit 0).

## 2. No way around a busy port
13337 in use → raw `Bind for 127.0.0.1:13337 failed: port is already allocated`. Now:
- Host port is `RECON_DECK_PORT` (default 13337) — `RECON_DECK_PORT=13338 curl … | sh -s -- --beta`
- A clash prints an actionable hint (retry with another port / how to find the holder)
- A failed run clears the stale `Created` container so the retry isn't blocked

## 3. `/api/health` reported `"version":"unknown"`
`npm_package_version` isn't set under `node server.js`. Version is now inlined from `package.json` at build via next.config `env` (`APP_VERSION`) — confirmed present in the built `health/route.js`.

## 4. Onboarding boot mockup hardcoded `v2.0.1`
Now uses the same `APP_VERSION` constant, so it tracks the real release (confirmed inlined into the welcome chunk).

## Verification
- `sh -n` / `dash -n` pass · `sh install.sh --help` exit 0
- `tsc` clean · `next build` compiles · `2.5.0-beta.8` inlined into health + welcome build output · **583/583** tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)