### PR TITLE
feat(ai): recommend free OpenRouter models + FREE badge

### DIFF
--- a/src/components/AiSettingsSection.tsx
+++ b/src/components/AiSettingsSection.tsx
@@ -381,6 +381,7 @@ export function AiSettingsSection({ initial }: { initial: AiSettingsInitial }) {
                       const active = m.id === model;
                       const inM = pricePerMillion(m.promptPrice);
                       const outM = pricePerMillion(m.completionPrice);
+                      const isFree = inM === 0 && outM === 0;
                       const price =
                         inM !== undefined && outM !== undefined
                           ? `$${inM.toFixed(2)}/$${outM.toFixed(2)}`
@@ -395,7 +396,11 @@ export function AiSettingsSection({ initial }: { initial: AiSettingsInitial }) {
                           }}
                           title={
                             (m.name ? m.name + " · " : "") +
-                            (price ? price + " per 1M (in/out)" : "price n/a") +
+                            (isFree
+                              ? "free ($0)"
+                              : price
+                                ? price + " per 1M (in/out)"
+                                : "price n/a") +
                             (m.contextLength ? ` · ctx ${m.contextLength}` : "")
                           }
                           style={{
@@ -418,10 +423,27 @@ export function AiSettingsSection({ initial }: { initial: AiSettingsInitial }) {
                             {star && <span style={{ color: "var(--accent)" }}>★ </span>}
                             {m.id}
                           </span>
-                          {price && (
-                            <span style={{ flexShrink: 0, fontSize: 10, color: "var(--fg-subtle)" }}>
-                              {price}
+                          {isFree ? (
+                            <span
+                              style={{
+                                flexShrink: 0,
+                                fontSize: 9,
+                                fontWeight: 700,
+                                letterSpacing: "0.04em",
+                                color: "var(--accent)",
+                                border: "1px solid var(--accent-border)",
+                                borderRadius: 3,
+                                padding: "0 5px",
+                              }}
+                            >
+                              FREE
                             </span>
+                          ) : (
+                            price && (
+                              <span style={{ flexShrink: 0, fontSize: 10, color: "var(--fg-subtle)" }}>
+                                {price}
+                              </span>
+                            )
                           )}
                         </button>
                       );

--- a/src/lib/ai/providers.ts
+++ b/src/lib/ai/providers.ts
@@ -46,17 +46,27 @@ export const AI_PROVIDER_ORDER: AiProvider[] = ["ollama", "openai", "openrouter"
 
 /**
  * Curated models that work well for recon-deck's explain/suggest tasks —
- * cheap, strong instruction-following, reliable JSON. Surfaced as
- * "Recommended" at the top of the picker when present in the provider list.
- * (OpenRouter ids; a `:free` variant is included where one commonly exists.)
+ * strong instruction-following, reliable structured/JSON output, and neutral
+ * enough not to refuse a pentest context. Surfaced as "Recommended" at the top
+ * of the picker, and only when the provider actually lists the id (so the free
+ * OpenRouter ids simply don't appear for OpenAI/Ollama users).
+ *
+ * The `:free` entries are OpenRouter's zero-cost tier (rate-limited but $0) —
+ * good enough for explain/suggest on a budget. Free slugs churn; treat this as
+ * a best-effort default, not a guarantee. Verified against OpenRouter's free
+ * collection, 2026-06.
  */
 export const RECOMMENDED_MODEL_IDS: string[] = [
+  // Paid — cheap, dependable JSON, fast.
   "openai/gpt-4o-mini",
   "anthropic/claude-3.5-haiku",
-  "google/gemini-2.0-flash-001",
   "deepseek/deepseek-chat",
-  "meta-llama/llama-3.3-70b-instruct",
-  "qwen/qwen-2.5-72b-instruct",
+  // Free ($0) — strong at command generation + structured output for "Suggest",
+  // and steerable for security work. Hermes 3 in particular stays neutral on
+  // offensive-security prompts instead of refusing.
+  "qwen/qwen3-coder:free",
+  "openai/gpt-oss-120b:free",
+  "nousresearch/hermes-3-llama-3.1-405b:free",
   "meta-llama/llama-3.3-70b-instruct:free",
 ];
 


### PR DESCRIPTION
## What

Operators on a budget had no signal about which $0 models are worth using. This:

1. **Refreshes the recommended set** with current free OpenRouter tiers that fit recon-deck's tasks (command generation + reliable structured/JSON output, and neutral on offensive-security prompts rather than refusing):
   - `qwen/qwen3-coder:free` — coding/commands + structured output, 1M ctx
   - `openai/gpt-oss-120b:free` — native tool use + structured output
   - `nousresearch/hermes-3-llama-3.1-405b:free` — steerable, stays neutral on security work
   - `meta-llama/llama-3.3-70b-instruct:free` — dependable

   Paid budget picks (`gpt-4o-mini`, `claude-3.5-haiku`, `deepseek-chat`) stay.

2. **Adds a green FREE badge** in the model picker for any $0 model (prompt + completion price both 0), so free options stand out instead of reading as "$0.00/$0.00".

## Notes

- Researched against OpenRouter's free collection (2026-06). Free slugs churn, so this is best-effort — the picker only surfaces ids the provider actually lists, so stale/removed ones silently disappear and non-OpenRouter providers are unaffected.
- The "good for cyber" lean: Hermes 3 and Qwen are chosen partly because they don't refuse legitimate pentest/recon prompts the way heavily-aligned models can; recon-deck remains suggest-never-execute and KB-grounded regardless.

## Verification
- `tsc` clean · `eslint` clean · `next build` compiles · **583/583** tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)