### PR TITLE
fix: 421 on custom host-port + correct RECON_DECK_PORT hint

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -111,8 +111,9 @@ if [ "$run_failed" -ne 0 ]; then
   case "$run_err" in
     *"already allocated"* | *"address already in use"* | *"port is already"*)
       printf 'Port %s is already in use.\n' "$PORT" >&2
-      printf 'Re-run on a different port, e.g.:\n' >&2
-      printf '  RECON_DECK_PORT=13338 curl -sSL https://raw.githubusercontent.com/kocaemre/recon-deck/main/install.sh | sh -s -- --beta\n' >&2
+      printf 'Re-run on a different port — note RECON_DECK_PORT goes on the sh\n' >&2
+      printf 'side of the pipe, not curl (env only reaches the process it prefixes):\n' >&2
+      printf '  curl -sSL https://raw.githubusercontent.com/kocaemre/recon-deck/main/install.sh | RECON_DECK_PORT=13338 sh -s -- --beta\n' >&2
       printf 'Or find what holds it:  docker ps --filter "publish=%s"\n' "$PORT" >&2
       ;;
     *)

--- a/src/lib/security/host-validation.ts
+++ b/src/lib/security/host-validation.ts
@@ -39,8 +39,32 @@ export function getAllowedHosts(): Set<string> {
 }
 
 /**
- * Return true if the given Host header value is permitted.
+ * Loopback hostnames. The DNS-rebinding threat hinges on the *hostname* an
+ * attacker page resolves to 127.0.0.1 (e.g. `evil.com`) — the port is whatever
+ * the container is published on. So a loopback host is safe on ANY port, which
+ * is what lets a custom host-port mapping (RECON_DECK_PORT / `-p 13339:13337`)
+ * work: the browser sends `Host: localhost:13339` while the container's internal
+ * PORT is still 13337. We loosen the port for loopback names only; everything
+ * else (LAN/mDNS) still needs an exact RECON_DECK_TRUSTED_HOSTS match.
+ */
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+/** Strip the `:port` suffix, preserving a bracketed IPv6 literal (`[::1]`). */
+function hostnameOf(host: string): string {
+  if (host.startsWith("[")) {
+    const close = host.indexOf("]");
+    return close === -1 ? host : host.slice(0, close + 1);
+  }
+  const colon = host.indexOf(":");
+  return colon === -1 ? host : host.slice(0, colon);
+}
+
+/**
+ * Return true if the given Host header value is permitted: an exact allowlist
+ * match (default port + configured trusted hosts), or any loopback hostname
+ * regardless of port.
  */
 export function isHostAllowed(host: string): boolean {
-  return getAllowedHosts().has(host);
+  if (getAllowedHosts().has(host)) return true;
+  return LOOPBACK_HOSTNAMES.has(hostnameOf(host));
 }

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -9,7 +9,10 @@
  */
 
 import { describe, it, expect, afterEach } from "vitest";
-import { getAllowedHosts } from "../src/lib/security/host-validation.js";
+import {
+  getAllowedHosts,
+  isHostAllowed,
+} from "../src/lib/security/host-validation.js";
 
 describe("Host-header validation (SEC-01)", () => {
   const originalTrustedHosts = process.env.RECON_DECK_TRUSTED_HOSTS;
@@ -99,5 +102,52 @@ describe("Host-header validation (SEC-01)", () => {
     expect(hosts.has("localhost:13337")).toBe(true);
     expect(hosts.has("127.0.0.1:13337")).toBe(true);
     expect(hosts.has("[::1]:13337")).toBe(true);
+  });
+});
+
+describe("isHostAllowed — loopback on any port (custom host-port mapping)", () => {
+  const originalTrustedHosts = process.env.RECON_DECK_TRUSTED_HOSTS;
+  const originalPort = process.env.PORT;
+
+  afterEach(() => {
+    if (originalTrustedHosts === undefined) {
+      delete process.env.RECON_DECK_TRUSTED_HOSTS;
+    } else {
+      process.env.RECON_DECK_TRUSTED_HOSTS = originalTrustedHosts;
+    }
+    if (originalPort === undefined) {
+      delete process.env.PORT;
+    } else {
+      process.env.PORT = originalPort;
+    }
+  });
+
+  it("allows loopback hosts on a non-default port (RECON_DECK_PORT=13339 → 421 fix)", () => {
+    delete process.env.RECON_DECK_TRUSTED_HOSTS;
+    delete process.env.PORT; // container's internal PORT stays 13337
+    expect(isHostAllowed("localhost:13339")).toBe(true);
+    expect(isHostAllowed("127.0.0.1:13339")).toBe(true);
+    expect(isHostAllowed("[::1]:13339")).toBe(true);
+  });
+
+  it("allows a bare loopback host with no port", () => {
+    expect(isHostAllowed("localhost")).toBe(true);
+    expect(isHostAllowed("127.0.0.1")).toBe(true);
+  });
+
+  it("still rejects non-loopback hosts on any port (rebinding stays blocked)", () => {
+    delete process.env.RECON_DECK_TRUSTED_HOSTS;
+    expect(isHostAllowed("evil.com:13339")).toBe(false);
+    expect(isHostAllowed("evil.com")).toBe(false);
+    // no prefix/suffix bypass of the loopback names
+    expect(isHostAllowed("localhost.evil.com:13339")).toBe(false);
+    expect(isHostAllowed("notlocalhost:13339")).toBe(false);
+  });
+
+  it("still honours an exact RECON_DECK_TRUSTED_HOSTS match", () => {
+    process.env.RECON_DECK_TRUSTED_HOSTS = "mybox.local:13337";
+    expect(isHostAllowed("mybox.local:13337")).toBe(true);
+    // but not that LAN host on a different port (exact match only for non-loopback)
+    expect(isHostAllowed("mybox.local:9999")).toBe(false);
   });
 });


### PR DESCRIPTION
Two follow-ups from the beta-image QA pass (thanks @Hermes):

## 1. `421 Misdirected Request` on a custom port (the real bug)
The SEC-01 host-header allowlist is built from the container's **internal** `PORT` (13337). A custom host-port mapping (`RECON_DECK_PORT=13339` → `-p 13339:13337`) makes the browser send `Host: localhost:13339`, which isn't in the `:13337` allowlist → **421**.

`isHostAllowed` now accepts any **loopback hostname** (`localhost` / `127.0.0.1` / `[::1]`) on **any port**. This is safe: DNS-rebinding hinges on the *hostname* an attacker resolves to 127.0.0.1 (e.g. `evil.com`), which still never matches a loopback name — we loosen only the **port**, and only for loopback. Non-loopback LAN/mDNS hosts still require an exact `RECON_DECK_TRUSTED_HOSTS` match (incl. port). No prefix bypass (`localhost.evil.com` → rejected).

## 2. Wrong `RECON_DECK_PORT` hint in the installer
The error hint suggested `RECON_DECK_PORT=13338 curl … | sh` — but env only reaches `curl`, not the piped `sh`, so the script never saw it. Corrected to put the env on the **sh** side:
```
curl … | RECON_DECK_PORT=13338 sh -s -- --beta
```

## Verification
- `sh -n` / `dash -n` pass on install.sh
- 14 host-validation tests (incl. loopback-any-port + rebinding-still-blocked) · `tsc` clean · **587/587** tests

## Note on the stale `main/install.sh`
The one-liner fetches `main/install.sh`, so the POSIX fix (#beta.9) + these hints only reach users once install.sh is on `main`. Handling that as a separate surgical install.sh hotfix to main (not a full v2.5.0 stable promotion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)