### PR TITLE
hotfix(installer): POSIX sh-compat + RECON_DECK_PORT on main

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # recon-deck — one-liner Docker installer.
 #
@@ -16,12 +16,16 @@
 #   3. Creates persistent named volumes for the SQLite DB + user KB.
 #   4. Runs the container detached on 127.0.0.1:13337 (loopback only — solo
 #      pentest tool, never exposed to LAN by default). Port 13337 was picked
-#      to dodge the dev-server crowd that lives on 3000/8080.
+#      to dodge the dev-server crowd that lives on 3000/8080. Override with
+#      RECON_DECK_PORT=13338 if 13337 is taken.
 #   5. Tries to open the browser (Linux: xdg-open, macOS: open).
 #
 # To uninstall: `docker rm -f recon-deck && docker volume rm recondeck-data recondeck-kb`.
 
-set -euo pipefail
+# POSIX sh — no bashisms — so the documented `curl ... | sh` works under dash
+# (Debian/Ubuntu /bin/sh). `pipefail` is bash-only and would abort dash with
+# "Illegal option -o pipefail" the moment the script is piped to sh.
+set -eu
 
 # Channel selection — default stable (:latest), opt into pre-releases with --beta.
 CHANNEL_TAG="latest"
@@ -42,7 +46,9 @@ done
 
 IMAGE="ghcr.io/kocaemre/recon-deck:${CHANNEL_TAG}"
 CONTAINER_NAME="recon-deck"
-PORT="13337"
+# Host port — override with RECON_DECK_PORT if 13337 is already taken. The
+# container always listens on 13337 internally; only the host side moves.
+PORT="${RECON_DECK_PORT:-13337}"
 URL="http://localhost:${PORT}"
 
 # 1. Pre-flight — docker reachable?
@@ -86,15 +92,36 @@ if docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
   docker rm -f "$CONTAINER_NAME" >/dev/null
 fi
 
-# 4. Run.
-docker run -d \
+# 4. Run. Capture stderr (stdout = container id, discarded) so a port clash
+#    gives an actionable hint instead of a raw docker traceback.
+run_failed=0
+run_err="$(docker run -d \
   --name "$CONTAINER_NAME" \
   --restart unless-stopped \
   -p "127.0.0.1:${PORT}:13337" \
   -v recondeck-data:/data \
   -v recondeck-kb:/kb \
   -e HOSTNAME=0.0.0.0 \
-  "$IMAGE" >/dev/null
+  "$IMAGE" 2>&1 >/dev/null)" || run_failed=1
+
+if [ "$run_failed" -ne 0 ]; then
+  # A failed run can leave a "Created" container holding the name — clear it so
+  # a re-run with a different port isn't blocked by the stale name.
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  case "$run_err" in
+    *"already allocated"* | *"address already in use"* | *"port is already"*)
+      printf 'Port %s is already in use.\n' "$PORT" >&2
+      printf 'Re-run on a different port — note RECON_DECK_PORT goes on the sh\n' >&2
+      printf 'side of the pipe, not curl (env only reaches the process it prefixes):\n' >&2
+      printf '  curl -sSL https://raw.githubusercontent.com/kocaemre/recon-deck/main/install.sh | RECON_DECK_PORT=13338 sh -s -- --beta\n' >&2
+      printf 'Or find what holds it:  docker ps --filter "publish=%s"\n' "$PORT" >&2
+      ;;
+    *)
+      printf 'docker run failed:\n%s\n' "$run_err" >&2
+      ;;
+  esac
+  exit 1
+fi
 
 printf '\nrecon-deck is up at %s\n' "$URL"
 printf 'Stop  : docker stop %s\n' "$CONTAINER_NAME"


### PR DESCRIPTION
## Why this goes straight to `main`

The install one-liner fetches `install.sh` from **`main`**, regardless of `--beta`. The sh-compat fix landed on `develop` (beta.9+) but the documented command still fails for everyone because it reads `main/install.sh`:

```
$ curl -fsSL …/main/install.sh | sh -s -- --help
sh: set: Illegal option -o pipefail
```

This is a **script-only hotfix** — no app code, no image, no version bump. `main` stays v2.4.1. It just makes the documented installer work (for both stable and `--beta`).

## Changes (install.sh only)
- POSIX: `#!/bin/sh` + `set -eu` (no bashisms) → `| sh` works under dash (Debian/Ubuntu).
- `RECON_DECK_PORT` host-port override + friendly port-clash hint (env on the **sh** side of the pipe).

## Known limitation
Custom-port access on the stable `:latest` (2.4.1) image still returns 421 until the host-header fix ships with v2.5.0. The **default** port works today, and `--beta` pulls the beta image where custom port already works (beta.11).

## Verification
- `sh -n` / `dash -n` pass · `sh install.sh --help` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)