### PR TITLE
fix(export): findings in markdown/json/html + real version

### DIFF
--- a/src/lib/export/__tests__/findings-report.test.ts
+++ b/src/lib/export/__tests__/findings-report.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { buildFixtureViewModel } from "./fixture-vm";
+import { generateMarkdown } from "../markdown";
+import { generateJson } from "../json";
+import { generateHtml } from "../html";
+
+/**
+ * Regression for the reporting-correctness bug: findings were rendered in the
+ * CSV / SysReptor / PwnDoc exports but silently dropped from the Markdown /
+ * JSON / HTML reports — the formats operators actually share. These assert all
+ * three now carry findings (severity-sorted, with affected host/port resolved).
+ */
+
+type Finding = ReturnType<
+  typeof buildFixtureViewModel
+>["engagement"]["findings"][number];
+
+function vmWithFindings() {
+  const vm = buildFixtureViewModel();
+  const base = {
+    engagement_id: 1,
+    evidenceRefs: [] as number[],
+    created_at: "2026-06-18T00:00:00.000Z",
+    updated_at: "2026-06-18T00:00:00.000Z",
+  };
+  const findings = [
+    {
+      ...base,
+      id: 1,
+      port_id: 3, // PORT_A_ID → 443/tcp https on the primary host
+      severity: "medium",
+      title: "SMB signing not required",
+      description: "Signing disabled; relay candidate.",
+      cve: null,
+    },
+    {
+      ...base,
+      id: 2,
+      port_id: null, // engagement-level
+      severity: "high",
+      title: "Reused local admin <creds>",
+      description: "",
+      cve: "CVE-2024-1234",
+    },
+  ] as unknown as Finding[];
+  // buildFixtureViewModel() returns a shared object graph — clone the top level
+  // + engagement so injecting findings doesn't leak into other tests.
+  return { ...vm, engagement: { ...vm.engagement, findings } };
+}
+
+describe("findings in report exports (markdown / json / html)", () => {
+  it("markdown: severity-sorted Findings section with affected + cve", () => {
+    const md = generateMarkdown(vmWithFindings(), {
+      exportedAt: "2026-06-18T00:00:00.000Z",
+    });
+    expect(md).toContain("## Findings");
+    // high before medium
+    const high = md.indexOf("[High] Reused local admin");
+    const medium = md.indexOf("[Medium] SMB signing not required");
+    expect(high).toBeGreaterThan(-1);
+    expect(medium).toBeGreaterThan(high);
+    expect(md).toContain("Signing disabled; relay candidate.");
+    expect(md).toContain("CVE-2024-1234");
+    expect(md).toContain("Affected:"); // the port-linked finding
+    expect(md).toContain("443/tcp");
+  });
+
+  it("json: findings array carries every finding with resolved affected", () => {
+    const parsed = JSON.parse(generateJson(vmWithFindings()));
+    expect(Array.isArray(parsed.findings)).toBe(true);
+    expect(parsed.findings).toHaveLength(2);
+    expect(parsed.findings[0].severity).toBe("high"); // sorted
+    expect(parsed.findings[0].cve).toBe("CVE-2024-1234");
+    expect(parsed.findings[0].affected).toBeNull();
+    const portLinked = parsed.findings.find(
+      (f: { title: string }) => f.title === "SMB signing not required",
+    );
+    expect(portLinked.affected.port).toBe(443);
+  });
+
+  it("json: findings is an empty array when there are none", () => {
+    const parsed = JSON.parse(generateJson(buildFixtureViewModel()));
+    expect(parsed.findings).toEqual([]);
+  });
+
+  it("html: Findings section escapes user content", () => {
+    const html = generateHtml(vmWithFindings());
+    expect(html).toContain("<h2>Findings</h2>");
+    expect(html).toContain("Reused local admin &lt;creds&gt;");
+    expect(html).not.toContain("admin <creds>");
+  });
+});

--- a/src/lib/export/__tests__/json.test.ts
+++ b/src/lib/export/__tests__/json.test.ts
@@ -39,6 +39,7 @@ describe("generateJson — Contract (EXPORT-03)", () => {
       "scan",
       "checklist",
       "notes",
+      "findings",
     ]);
   });
 

--- a/src/lib/export/findings-shared.ts
+++ b/src/lib/export/findings-shared.ts
@@ -1,0 +1,106 @@
+import "server-only";
+
+/**
+ * Shared findings enrichment for the Markdown / JSON / HTML exports.
+ *
+ * The CSV / SysReptor / PwnDoc formatters each resolve a finding's affected
+ * host/port inline; this consolidates that logic so the three report-style
+ * exports (which previously omitted findings entirely — a reporting-correctness
+ * bug) render them consistently: severity-sorted, with the affected host/port
+ * resolved from the view model.
+ */
+
+import type { EngagementViewModel } from "./view-model";
+
+/** Severity render order — critical first. */
+export const SEVERITY_RANK: Record<string, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  info: 4,
+};
+
+export interface EnrichedFinding {
+  id: number;
+  severity: string;
+  title: string;
+  description: string | null;
+  cve: string | null;
+  createdAt: string;
+  /** "hostname (ip)" or "ip" for a port-linked finding; null when engagement-level. */
+  host: string | null;
+  port: number | null;
+  protocol: string | null;
+  service: string | null;
+}
+
+/**
+ * Resolve + severity-sort an engagement's findings. Port-linked findings carry
+ * their affected host/port/service; engagement-level findings (port_id = null)
+ * leave those fields null.
+ */
+export function enrichFindings(vm: EngagementViewModel): EnrichedFinding[] {
+  const portIndex = new Map<
+    number,
+    {
+      port: number;
+      protocol: string;
+      service: string | null;
+      hostIp: string;
+      hostHostname: string | null;
+    }
+  >();
+  for (const hvm of vm.hosts) {
+    for (const pvm of hvm.ports) {
+      portIndex.set(pvm.port.id, {
+        port: pvm.port.port,
+        protocol: pvm.port.protocol,
+        service: pvm.port.service,
+        hostIp: hvm.host.ip,
+        hostHostname: hvm.host.hostname,
+      });
+    }
+  }
+  // Defensive fallback for single-host VMs that don't populate vm.hosts.
+  if (portIndex.size === 0) {
+    const primaryHost = vm.engagement.hosts[0];
+    for (const pvm of vm.ports) {
+      portIndex.set(pvm.port.id, {
+        port: pvm.port.port,
+        protocol: pvm.port.protocol,
+        service: pvm.port.service,
+        hostIp: primaryHost?.ip ?? "",
+        hostHostname: primaryHost?.hostname ?? null,
+      });
+    }
+  }
+
+  return [...vm.engagement.findings]
+    .sort((a, b) => {
+      const sa = SEVERITY_RANK[a.severity] ?? 99;
+      const sb = SEVERITY_RANK[b.severity] ?? 99;
+      if (sa !== sb) return sa - sb;
+      return a.title.localeCompare(b.title);
+    })
+    .map((f) => {
+      const info = f.port_id != null ? portIndex.get(f.port_id) : null;
+      const host = info
+        ? info.hostHostname
+          ? `${info.hostHostname} (${info.hostIp})`
+          : info.hostIp
+        : null;
+      return {
+        id: f.id,
+        severity: f.severity,
+        title: f.title,
+        description: f.description ?? null,
+        cve: f.cve ?? null,
+        createdAt: f.created_at,
+        host,
+        port: info?.port ?? null,
+        protocol: info?.protocol ?? null,
+        service: info?.service ?? null,
+      };
+    });
+}

--- a/src/lib/export/html.ts
+++ b/src/lib/export/html.ts
@@ -36,6 +36,7 @@ import type {
 } from "./view-model";
 import type { PortScript } from "@/lib/db/schema";
 import { escapeHtml } from "./escape";
+import { enrichFindings } from "./findings-shared";
 
 // -----------------------------------------------------------------------------
 // Inline CSS (D-14 palette; D-18 page-break rule)
@@ -114,6 +115,11 @@ function generateBody(vm: EngagementViewModel): string {
   const parts: string[] = [];
   parts.push(renderHeader(vm));
 
+  // Findings — right after the header so the report payload is up top. Omitted
+  // when empty so the golden HTML fixture stays byte-stable.
+  const findingsSection = renderFindingsSection(vm);
+  if (findingsSection) parts.push(findingsSection);
+
   // P1-F PR 3: multi-host engagements wrap their port grids inside per-host
   // <section class="host-block"> wrappers, mirroring the markdown layout.
   // Single-host engagements emit the legacy flat layout (golden HTML fixture
@@ -138,6 +144,43 @@ function generateBody(vm: EngagementViewModel): string {
   const extra = renderExtraSections(vm);
   if (extra) parts.push(extra);
   return parts.join("\n");
+}
+
+/**
+ * Render the Findings section, severity-sorted. Returns null when there are no
+ * findings so the section (and the golden fixture) stays byte-stable.
+ */
+function renderFindingsSection(vm: EngagementViewModel): string | null {
+  const findings = enrichFindings(vm);
+  if (findings.length === 0) return null;
+
+  const items = findings
+    .map((f) => {
+      const sev = f.severity.charAt(0).toUpperCase() + f.severity.slice(1);
+      const meta: string[] = [];
+      if (f.host) {
+        const portPart =
+          f.port != null
+            ? ` · ${f.port}/${escapeHtml(f.protocol ?? "")}${
+                f.service ? ` ${escapeHtml(f.service)}` : ""
+              }`
+            : "";
+        meta.push(`Affected: ${escapeHtml(f.host)}${portPart}`);
+      }
+      if (f.cve) meta.push(escapeHtml(f.cve));
+      const metaLine =
+        meta.length > 0
+          ? `<p class="finding-meta"><em>${meta.join(" · ")}</em></p>\n`
+          : "";
+      const desc =
+        f.description && f.description.trim()
+          ? `<p>${escapeHtml(f.description.trim())}</p>\n`
+          : "";
+      return `<div class="finding finding-${escapeHtml(f.severity)}">\n<h3>[${escapeHtml(sev)}] ${escapeHtml(f.title)}</h3>\n${metaLine}${desc}</div>`;
+    })
+    .join("\n");
+
+  return `<section class="findings">\n<h2>Findings</h2>\n${items}\n</section>`;
 }
 
 /**

--- a/src/lib/export/json.ts
+++ b/src/lib/export/json.ts
@@ -41,6 +41,7 @@ import "server-only";
  */
 
 import type { EngagementViewModel, PortViewModel } from "./view-model";
+import { enrichFindings } from "./findings-shared";
 
 // -----------------------------------------------------------------------------
 // Internal helpers
@@ -291,6 +292,26 @@ export function generateJson(vm: EngagementViewModel): string {
   //    are not broken until they explicitly opt into v2 by sending a
   //    multi-host scan.
   const schemaVersion = vm.hosts.length > 1 ? "2.0" : "1.0";
+  // 5b. Findings — severity-sorted, affected host/port resolved. Always present
+  //     (empty array when none) so downstream consumers get a stable schema.
+  const findings = enrichFindings(vm).map((f) => ({
+    id: f.id,
+    severity: f.severity,
+    title: f.title,
+    description: f.description,
+    cve: f.cve,
+    created_at: f.createdAt,
+    affected:
+      f.host != null
+        ? {
+            host: f.host,
+            port: f.port,
+            protocol: f.protocol,
+            service: f.service,
+          }
+        : null,
+  }));
+
   const output = {
     schema_version: schemaVersion as "1.0" | "2.0",
     recon_deck_version: vm.recon_deck_version,
@@ -298,6 +319,7 @@ export function generateJson(vm: EngagementViewModel): string {
     scan,
     checklist,
     notes,
+    findings,
   };
 
   // 7. Pretty-print with 2-space indent — small footprint, diffable in PRs.

--- a/src/lib/export/markdown.ts
+++ b/src/lib/export/markdown.ts
@@ -57,6 +57,7 @@ import type {
   PortViewModel,
 } from "./view-model";
 import type { PortScript } from "@/lib/db/schema";
+import { enrichFindings } from "./findings-shared";
 
 // -----------------------------------------------------------------------------
 // Public API
@@ -184,6 +185,14 @@ function buildBody(vm: EngagementViewModel): string {
     parts.push(`## Writeup\n\n${writeup}\n\n---`);
   }
 
+  // Findings — the report payload. Slots after the writeup (exec summary) and
+  // before the technical per-port detail. Omitted entirely when there are none
+  // so engagements without findings keep the legacy layout byte-for-byte.
+  const findingsSection = buildFindingsSection(vm);
+  if (findingsSection) {
+    parts.push(findingsSection);
+  }
+
   // 2. P1-F PR 3: multi-host engagements emit one block per host. Single-host
   //    engagements keep the legacy layout byte-for-byte (golden fixtures stay
   //    stable). The choice between the two paths uses `vm.hosts.length` —
@@ -215,6 +224,36 @@ function buildBody(vm: EngagementViewModel): string {
   }
 
   return parts.join("\n\n");
+}
+
+/**
+ * Build the `## Findings` section, severity-sorted. Returns null when the
+ * engagement has no findings so the section is skipped entirely.
+ */
+function buildFindingsSection(vm: EngagementViewModel): string | null {
+  const findings = enrichFindings(vm);
+  if (findings.length === 0) return null;
+
+  const blocks = findings.map((f) => {
+    const sev = f.severity.charAt(0).toUpperCase() + f.severity.slice(1);
+    const lines: string[] = [`### [${sev}] ${f.title}`];
+    const meta: string[] = [];
+    if (f.host) {
+      const portPart =
+        f.port != null
+          ? ` · ${f.port}/${f.protocol}${f.service ? ` ${f.service}` : ""}`
+          : "";
+      meta.push(`Affected: ${f.host}${portPart}`);
+    }
+    if (f.cve) meta.push(f.cve);
+    if (meta.length > 0) lines.push("", `*${meta.join(" · ")}*`);
+    if (f.description && f.description.trim()) {
+      lines.push("", f.description.trim());
+    }
+    return lines.join("\n");
+  });
+
+  return `## Findings\n\n${blocks.join("\n\n")}`;
 }
 
 /**

--- a/src/lib/export/view-model.ts
+++ b/src/lib/export/view-model.ts
@@ -368,11 +368,12 @@ export function loadEngagementForExport(
   const coverage =
     totalChecks === 0 ? 0 : Math.round((doneChecks / totalChecks) * 100);
 
-  // 5. recon_deck_version — npm injects package.json `version` into
-  //    process.env.npm_package_version when running `npm run` / `npm test`.
-  //    In bundled production Next.js, next.config may surface it via env — for
-  //    now fall back to a placeholder so exports never emit `"undefined"`.
-  const recon_deck_version = process.env.npm_package_version ?? "0.0.0-dev";
+  // 5. recon_deck_version — APP_VERSION is inlined from package.json at build
+  //    time via next.config (`env`), so exports carry the real release inside
+  //    the container where `node server.js` leaves npm_package_version unset.
+  //    The fallbacks keep dev/test sane (npm sets npm_package_version there).
+  const recon_deck_version =
+    process.env.APP_VERSION ?? process.env.npm_package_version ?? "0.0.0-dev";
 
   // 6. P1-F PR 3: group ports by host. engagement.hosts is already sorted
   //    primary-first then by IP (engagement-repo.getById invariant). For each

--- a/tests/golden/engagement.json
+++ b/tests/golden/engagement.json
@@ -102,5 +102,6 @@
   },
   "notes": {
     "80/tcp": "Looked at main page, see screenshot-01.png in HackTricks folder"
-  }
+  },
+  "findings": []
 }


### PR DESCRIPTION
Two reporting-correctness bugs from the beta QA pass (thanks @Hermes).

## P1 (release blocker) — Findings dropped from Markdown / JSON / HTML
Findings rendered in CSV / SysReptor / PwnDoc but **vanished** from the three formats operators actually share. A finding added in the UI silently disappeared from the report — unacceptable for a "recon → report" tool.

Added a severity-sorted Findings section to all three, with the affected host/port resolved:
- **markdown**: `## Findings` after the writeup. Omitted when there are none, so finding-less engagements keep the golden layout byte-for-byte.
- **html**: a `<section class="findings">` (HTML-escaped). Omitted when none.
- **json**: a top-level `findings[]`, **always present** (empty array when none) so downstream consumers get a stable schema.

Shared resolution in `findings-shared.ts` mirrors the CSV port→host logic so every formatter agrees.

## P2 (medium) — Exports stamped `0.0.0-dev`
Same root cause as the health bug: `npm_package_version` is unset under `node server.js`. The view-model now reads `APP_VERSION` (inlined from package.json via next.config) first, so reports carry the real release (e.g. `2.5.0-beta.x`).

## Tests
- New `findings-report.test.ts`: asserts md/json/html all carry findings (severity-sorted, affected host/port resolved, HTML-escaped), and json `findings` is `[]` when none.
- json key-order assertion updated; **golden `engagement.json` refreshed** for the new `findings` key. Markdown/HTML goldens unchanged.
- `tsc` clean · `next build` compiles · **591/591** tests.

## Deferred (low, from same report)
P3 settings spacing, P4 warning contrast, P5 AI panel UX (context preview / "Add to My Commands"), P6 writeup focus — tracked for a later polish pass, not blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)