### PR TITLE
fix: findings-csv export alias + root-safe probe tests

### DIFF
--- a/app/api/engagements/[id]/export/[format]/route.ts
+++ b/app/api/engagements/[id]/export/[format]/route.ts
@@ -46,6 +46,9 @@ const FORMATS = {
   json: { ext: "json", contentType: "application/json; charset=utf-8" },
   html: { ext: "html", contentType: "text/html; charset=utf-8" },
   csv: { ext: "csv", contentType: "text/csv; charset=utf-8" },
+  // Alias for `csv` — the csv export IS the findings CSV, and the export menu
+  // labels it "Findings CSV", so the self-documenting URL works too.
+  "findings-csv": { ext: "csv", contentType: "text/csv; charset=utf-8" },
   sysreptor: {
     ext: "sysreptor.json",
     contentType: "application/json; charset=utf-8",
@@ -63,6 +66,7 @@ function isFormat(x: string): x is Format {
     x === "json" ||
     x === "html" ||
     x === "csv" ||
+    x === "findings-csv" ||
     x === "sysreptor" ||
     x === "pwndoc"
   );
@@ -146,6 +150,7 @@ export async function GET(
         body = generateHtml(vm);
         break;
       case "csv":
+      case "findings-csv":
         body = generateFindingsCsv(vm);
         break;
       case "sysreptor":

--- a/src/lib/db/__tests__/probe.test.ts
+++ b/src/lib/db/__tests__/probe.test.ts
@@ -4,6 +4,13 @@ import os from "node:os";
 import path from "node:path";
 import { checkWritability } from "../probe.js";
 
+// The read-only-directory tests rely on a 0o444 chmod actually denying writes.
+// Root bypasses permission bits, so under root (common in CI containers / the
+// QA Docker box) the probe succeeds and the expected process.exit never fires.
+// Skip those two cases when running as root rather than report a false failure.
+const isRoot =
+  typeof process.getuid === "function" && process.getuid() === 0;
+
 describe("checkWritability (Plan 02)", () => {
   const dirs: string[] = [];
 
@@ -46,7 +53,7 @@ describe("checkWritability (Plan 02)", () => {
     expect(fs.existsSync(subdir)).toBe(true);
   });
 
-  it("PERSIST-06: calls process.exit(1) on read-only directory", () => {
+  it.skipIf(isRoot)("PERSIST-06: calls process.exit(1) on read-only directory", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "probe-ro-"));
     dirs.push(dir);
 
@@ -76,7 +83,7 @@ describe("checkWritability (Plan 02)", () => {
     fs.chmodSync(dir, 0o755);
   });
 
-  it("PERSIST-06: includes the directory path in error message", () => {
+  it.skipIf(isRoot)("PERSIST-06: includes the directory path in error message", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "probe-path-"));
     dirs.push(dir);
 

--- a/src/lib/export/__tests__/route.test.ts
+++ b/src/lib/export/__tests__/route.test.ts
@@ -67,12 +67,16 @@ vi.mock("@/lib/export/json", () => ({
 vi.mock("@/lib/export/html", () => ({
   generateHtml: vi.fn(() => "<!DOCTYPE html>"),
 }));
+vi.mock("@/lib/export/findings-csv", () => ({
+  generateFindingsCsv: vi.fn(() => "severity,title\r\n"),
+}));
 
 import { GET } from "../../../../app/api/engagements/[id]/export/[format]/route";
 import { getById } from "@/lib/db";
 import { generateMarkdown } from "@/lib/export/markdown";
 import { generateJson } from "@/lib/export/json";
 import { generateHtml } from "@/lib/export/html";
+import { generateFindingsCsv } from "@/lib/export/findings-csv";
 
 const FIXTURE_ENG = {
   id: 1,
@@ -148,6 +152,24 @@ describe("GET /api/engagements/[id]/export/[format]", () => {
         "text/html; charset=utf-8",
       );
       expect(await res.text()).toBe("<!DOCTYPE html>");
+    });
+
+    it("returns 200 + text/csv for format=csv", async () => {
+      vi.mocked(getById).mockReturnValue(FIXTURE_ENG as any);
+      const res = await GET(makeReq(), makeParams("1", "csv"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe("text/csv; charset=utf-8");
+      expect(vi.mocked(generateFindingsCsv)).toHaveBeenCalledTimes(1);
+    });
+
+    it("accepts findings-csv as an alias for csv", async () => {
+      vi.mocked(getById).mockReturnValue(FIXTURE_ENG as any);
+      const res = await GET(makeReq(), makeParams("1", "findings-csv"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe("text/csv; charset=utf-8");
+      // filename keeps the .csv extension
+      expect(res.headers.get("Content-Disposition")).toContain(".csv");
+      expect(vi.mocked(generateFindingsCsv)).toHaveBeenCalledTimes(1);
     });
 
     it("sets Cache-Control: no-store", async () => {


### PR DESCRIPTION
Two loose ends from the beta.12 QA pass (thanks @Hermes).

## 1. `findings-csv` export alias
The csv export **is** the findings CSV, and the export menu labels it "Findings CSV", but only `/api/engagements/:id/export/csv` worked — `/export/findings-csv` returned `400 Unknown format`. Added it as an alias (same generator, same `.csv` filename + content-type) so the self-documenting URL works. `csv` keeps working unchanged.

## 2. probe.test 2 failures under root
The read-only-directory cases `chmod 0o444` and expect the write probe to fail → `process.exit(1)`. **Root bypasses permission bits**, so under root (CI containers / the QA Docker box) the probe *succeeds* and the assertion fails — a false negative (our non-root CI was always green; this only bit root runs). They now `it.skipIf(process.getuid() === 0)` with an explanatory comment; non-root dev/CI still exercises them fully.

## Verification
- New route tests: `csv` → 200 text/csv, and `findings-csv` alias → 200 text/csv with `.csv` filename.
- `tsc` clean · `next build` compiles · **593/593** tests (probe cases run here as non-root).

## Still deferred (low, design/polish — not blockers)
Sidebar `ACTIVE1`/`ARCHIVED0` accessible-name spacing (aria-label), settings text-extraction whitespace, host-level findings default-open / port-detail-below-fold UX, AI panel niceties (context preview / "Add to My Commands" / "copy all safe" / intrusive tooltip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)