### PR TITLE
docs: how to update a beta install

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,24 @@ docker stop recon-deck && docker rm recon-deck
 # re-run docker run from Quick Start; named volumes survive
 ```
 
+**Beta:** updating a beta install works the same way — re-run the `--beta`
+one-liner (idempotent: pulls the newest `:beta`, replaces the container, volumes
+survive), or pull the image and re-run manually:
+
+```bash
+# easy — re-run to pull the latest pre-release
+curl -sSL https://raw.githubusercontent.com/kocaemre/recon-deck/main/install.sh | sh -s -- --beta
+
+# manual
+docker pull ghcr.io/kocaemre/recon-deck:beta
+docker stop recon-deck && docker rm recon-deck   # named volumes survive
+# re-run docker run with the :beta image
+```
+
+Move back to stable any time with `--stable` (or pull `:latest`). On a busy
+port, the `RECON_DECK_PORT` env goes on the **sh** side of the pipe:
+`… | RECON_DECK_PORT=13338 sh -s -- --beta`.
+
 **Local dev:** `git pull && npm install && npm run dev`. Migrations apply at boot.
 
 ## Tech Stack


### PR DESCRIPTION
The Upgrading section only documented stable upgrades — a beta user had no documented way to pull a newer pre-release.

Adds a **Beta** subsection to *Upgrading*:
- re-run the `--beta` one-liner (idempotent: pulls newest `:beta`, replaces container, volumes survive)
- manual `docker pull :beta` + re-run
- how to switch back to stable (`--stable` / `:latest`)
- the `RECON_DECK_PORT`-on-the-sh-side note for a busy port

Docs-only. The beta *install* docs already existed; this closes the *update* gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)