### PR TITLE
docs(main): how to update a beta install

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,24 @@ docker stop recon-deck && docker rm recon-deck
 # re-run docker run from Quick Start; named volumes survive
 ```
 
+**Beta:** updating a beta install works the same way — re-run the `--beta`
+one-liner (idempotent: pulls the newest `:beta`, replaces the container, volumes
+survive), or pull the image and re-run manually:
+
+```bash
+# easy — re-run to pull the latest pre-release
+curl -sSL https://raw.githubusercontent.com/kocaemre/recon-deck/main/install.sh | sh -s -- --beta
+
+# manual
+docker pull ghcr.io/kocaemre/recon-deck:beta
+docker stop recon-deck && docker rm recon-deck   # named volumes survive
+# re-run docker run with the :beta image
+```
+
+Move back to stable any time with `--stable` (or pull `:latest`). On a busy
+port, the `RECON_DECK_PORT` env goes on the **sh** side of the pipe:
+`… | RECON_DECK_PORT=13338 sh -s -- --beta`.
+
 **Local dev:** `git pull && npm install && npm run dev`. Migrations apply at boot.
 
 ## Tech Stack


### PR DESCRIPTION
Docs-only hotfix to **main** (the README GitHub shows). The beta-channel *install* docs already live on main, but the *Upgrading* section only covered stable — beta testers had no documented update path until the v2.5.0 promotion.

Adds the same **Beta** subsection as #65 (re-run `--beta` / pull `:beta`, switch back to stable, RECON_DECK_PORT-on-sh-side note). No app/version change; main stays v2.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)