### PR TITLE
feat(ui): AI panel UX + warning contrast + writeup focus + sidebar a11y

### DIFF
--- a/src/components/ExplainButton.tsx
+++ b/src/components/ExplainButton.tsx
@@ -14,6 +14,7 @@
 import { useState } from "react";
 import { Sparkles, Loader2, X } from "lucide-react";
 import { useAiStatus } from "@/components/ai/useAiStatus";
+import { AiContextPreview } from "@/components/ai/AiContextPreview";
 
 export interface ExplainContext {
   port: number;
@@ -177,6 +178,16 @@ export function ExplainButton(props: ExplainContext) {
                 the scan; it does not run anything.
               </div>
             )}
+            <AiContextPreview
+              context={{
+                port: props.port,
+                protocol: props.protocol ?? null,
+                service: props.service ?? null,
+                version: props.version ?? null,
+                scanOutput: props.scanOutput,
+              }}
+              cloud={status.cloud}
+            />
           </div>
         </div>
       )}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -609,6 +609,8 @@ function SekmeButton({
     <button
       type="button"
       onClick={onClick}
+      aria-pressed={active}
+      aria-label={`${label} engagements: ${count}`}
       className="uppercase tracking-[0.08em] font-medium"
       style={{
         flex: 1,

--- a/src/components/SuggestButton.tsx
+++ b/src/components/SuggestButton.tsx
@@ -10,9 +10,10 @@
  */
 
 import { useState } from "react";
-import { Wand2, Loader2, X } from "lucide-react";
+import { Wand2, Loader2, X, Plus, Check, Copy } from "lucide-react";
 import { useAiStatus } from "@/components/ai/useAiStatus";
 import { CopyButton } from "@/components/CopyButton";
+import { AiContextPreview } from "@/components/ai/AiContextPreview";
 
 interface Suggestion {
   command: string;
@@ -35,8 +36,43 @@ export function SuggestButton(props: SuggestContext) {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
+  // Index → "saved" | "error" for the per-card "Add to My Commands" action.
+  const [added, setAdded] = useState<Record<number, "saved" | "error">>({});
+  const [copiedSafe, setCopiedSafe] = useState(false);
 
   if (!status || !status.enabled) return null;
+
+  const safeCommands = items
+    .filter((s) => s.risk !== "intrusive")
+    .map((s) => s.command);
+
+  async function addToMyCommands(s: Suggestion, idx: number) {
+    try {
+      const res = await fetch("/api/user-commands", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          service: props.service ?? null,
+          port: props.port,
+          label: `AI: ${s.command.split(/\s+/)[0]} (${props.service ?? props.port})`,
+          template: s.command,
+        }),
+      });
+      setAdded((a) => ({ ...a, [idx]: res.ok ? "saved" : "error" }));
+    } catch {
+      setAdded((a) => ({ ...a, [idx]: "error" }));
+    }
+  }
+
+  async function copyAllSafe() {
+    try {
+      await navigator.clipboard.writeText(safeCommands.join("\n"));
+      setCopiedSafe(true);
+      window.setTimeout(() => setCopiedSafe(false), 1500);
+    } catch {
+      /* clipboard blocked — individual copy buttons still work */
+    }
+  }
 
   async function run() {
     setOpen(true);
@@ -183,6 +219,10 @@ export function SuggestButton(props: SuggestContext) {
                       </code>
                       <div style={{ display: "flex", alignItems: "center", gap: 6, flexShrink: 0 }}>
                         <RiskBadge risk={s.risk} />
+                        <AddToCommandsButton
+                          state={added[i]}
+                          onClick={() => addToMyCommands(s, i)}
+                        />
                         <CopyButton text={s.command} />
                       </div>
                     </div>
@@ -200,6 +240,30 @@ export function SuggestButton(props: SuggestContext) {
                     )}
                   </div>
                 ))}
+                {safeCommands.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={copyAllSafe}
+                    style={{
+                      alignSelf: "flex-start",
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 5,
+                      padding: "3px 9px",
+                      borderRadius: 5,
+                      border: "1px solid var(--border)",
+                      background: "var(--bg-2)",
+                      color: copiedSafe ? "var(--accent)" : "var(--fg-muted)",
+                      fontSize: 11,
+                      cursor: "pointer",
+                    }}
+                  >
+                    {copiedSafe ? <Check size={12} /> : <Copy size={12} />}
+                    {copiedSafe
+                      ? "Copied"
+                      : `Copy all safe (${safeCommands.length})`}
+                  </button>
+                )}
                 <div
                   style={{
                     fontSize: 10.5,
@@ -210,6 +274,17 @@ export function SuggestButton(props: SuggestContext) {
                   AI-generated — review each command before running it yourself.
                   Nothing here is executed automatically.
                 </div>
+                <AiContextPreview
+                  context={{
+                    port: props.port,
+                    protocol: props.protocol ?? null,
+                    service: props.service ?? null,
+                    version: props.version ?? null,
+                    scanOutput: props.scanOutput,
+                    kbCommands: props.kbCommands,
+                  }}
+                  cloud={status.cloud}
+                />
               </div>
             )}
           </div>
@@ -223,6 +298,11 @@ function RiskBadge({ risk }: { risk?: "safe" | "intrusive" }) {
   const intrusive = risk === "intrusive";
   return (
     <span
+      title={
+        intrusive
+          ? "Intrusive — may generate noisy or brute-force-like traffic. Run deliberately and only within scope."
+          : "Low-impact — read-only / enumeration, generally safe to run."
+      }
       style={{
         fontSize: 9.5,
         fontWeight: 700,
@@ -232,9 +312,56 @@ function RiskBadge({ risk }: { risk?: "safe" | "intrusive" }) {
         border: `1px solid ${intrusive ? "var(--warning-border, #b45309)" : "var(--border)"}`,
         background: intrusive ? "var(--warning-bg, rgba(180,83,9,0.14))" : "var(--bg-2)",
         color: intrusive ? "var(--warning, #d97706)" : "var(--fg-subtle)",
+        cursor: "help",
       }}
     >
       {intrusive ? "INTRUSIVE" : "SAFE"}
     </span>
+  );
+}
+
+/** Per-suggestion "Add to My Commands" button → POSTs to /api/user-commands. */
+function AddToCommandsButton({
+  state,
+  onClick,
+}: {
+  state?: "saved" | "error";
+  onClick: () => void;
+}) {
+  const saved = state === "saved";
+  const errored = state === "error";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={saved}
+      title={
+        saved
+          ? "Saved to My Commands (refresh to see it on the port)"
+          : errored
+            ? "Could not save — try again"
+            : "Add to My Commands for this port"
+      }
+      aria-label="Add to My Commands"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 3,
+        padding: "1px 6px",
+        borderRadius: 5,
+        border: "1px solid var(--border)",
+        background: "var(--bg-2)",
+        color: saved
+          ? "var(--accent)"
+          : errored
+            ? "var(--danger, #dc2626)"
+            : "var(--fg-subtle)",
+        fontSize: 10.5,
+        cursor: saved ? "default" : "pointer",
+      }}
+    >
+      {saved ? <Check size={11} /> : <Plus size={11} />}
+      {saved ? "Added" : "Add"}
+    </button>
   );
 }

--- a/src/components/WarningBanner.tsx
+++ b/src/components/WarningBanner.tsx
@@ -18,8 +18,13 @@ export function WarningBanner({ warnings }: WarningBannerProps) {
       role="alert"
       className="flex items-start gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3"
     >
-      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
-      <div className="flex-1 text-sm text-amber-200">
+      <AlertTriangle
+        className="mt-0.5 h-4 w-4 shrink-0"
+        style={{ color: "var(--risk-med)" }}
+      />
+      {/* Use the theme-flipping --risk-med token (#fbbf24 dark / #a16207 light)
+          instead of a fixed amber-200, which was too faint on the light theme. */}
+      <div className="flex-1 text-sm" style={{ color: "var(--risk-med)" }}>
         {warnings.map((w, i) => (
           <p key={i}>{w}</p>
         ))}
@@ -29,7 +34,8 @@ export function WarningBanner({ warnings }: WarningBannerProps) {
         size="sm"
         onClick={() => setVisible(false)}
         aria-label="Dismiss warning"
-        className="shrink-0 text-amber-400 hover:text-amber-300"
+        className="shrink-0"
+        style={{ color: "var(--risk-med)" }}
       >
         <X className="h-4 w-4" />
       </Button>

--- a/src/components/WriteupPanel.tsx
+++ b/src/components/WriteupPanel.tsx
@@ -38,6 +38,23 @@ export function WriteupPanel({ engagementId, initialWriteup }: Props) {
   const [pending, setPending] = useState(false);
   const lastSavedRef = useRef(initialWriteup);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // P6: opening the (collapsible) panel on a long engagement page left the
+  // operator unsure it opened — pull the textarea into view and focus it.
+  function toggleOpen() {
+    const next = !open;
+    setOpen(next);
+    if (next) {
+      window.setTimeout(() => {
+        textareaRef.current?.scrollIntoView({
+          behavior: "smooth",
+          block: "center",
+        });
+        textareaRef.current?.focus();
+      }, 50);
+    }
+  }
 
   const dirty = draft !== lastSavedRef.current;
 
@@ -98,7 +115,7 @@ export function WriteupPanel({ engagementId, initialWriteup }: Props) {
     >
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={toggleOpen}
         className="flex items-center gap-2"
         style={{
           width: "100%",
@@ -132,6 +149,7 @@ export function WriteupPanel({ engagementId, initialWriteup }: Props) {
       {open && (
         <div style={{ padding: "0 14px 14px" }}>
           <textarea
+            ref={textareaRef}
             value={draft}
             onChange={(ev) => setDraft(ev.target.value)}
             placeholder="Executive summary, narrative, findings rationale… plain text. Lands at the top of the Markdown export and in the SysReptor / PwnDoc notes field."

--- a/src/components/ai/AiContextPreview.tsx
+++ b/src/components/ai/AiContextPreview.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+/**
+ * AiContextPreview — collapsible "what gets sent" disclosure for the AI panels.
+ *
+ * Privacy affordance (P5): before trusting a cloud provider with scan data, an
+ * operator can expand this to see exactly what leaves the machine — the port
+ * identity, the NSE/scan output, and (for Suggest) the baseline KB commands.
+ * Shown for every provider; the wording leans on the cloud/local distinction.
+ */
+
+import { useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+
+export interface AiContextView {
+  port: number;
+  protocol?: string | null;
+  service?: string | null;
+  version?: string | null;
+  scanOutput: string;
+  kbCommands?: Array<{ label: string; command: string }>;
+}
+
+export function AiContextPreview({
+  context,
+  cloud,
+}: {
+  context: AiContextView;
+  cloud: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+
+  const portLine = [
+    `${context.port}/${context.protocol ?? "tcp"}`,
+    context.service ?? null,
+    context.version ?? null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const scan = (context.scanOutput ?? "").trim();
+  const kb = context.kbCommands ?? [];
+
+  return (
+    <div style={{ marginTop: 8 }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 4,
+          padding: "2px 4px",
+          marginLeft: -4,
+          background: "none",
+          border: "none",
+          color: "var(--fg-subtle)",
+          fontSize: 11,
+          cursor: "pointer",
+        }}
+      >
+        {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        {cloud ? "What gets sent to the provider" : "What the model sees"}
+      </button>
+
+      {open && (
+        <div
+          style={{
+            marginTop: 4,
+            border: "1px solid var(--border)",
+            borderRadius: 5,
+            background: "var(--code-surface, var(--bg-2))",
+            padding: "8px 10px",
+            fontSize: 11,
+            color: "var(--fg-muted)",
+            lineHeight: 1.5,
+          }}
+        >
+          <div>
+            <span style={{ color: "var(--fg-subtle)" }}>port:</span>{" "}
+            <span className="mono" style={{ color: "var(--fg)" }}>
+              {portLine}
+            </span>
+          </div>
+          <div style={{ marginTop: 6, color: "var(--fg-subtle)" }}>
+            scan output:
+          </div>
+          <pre
+            className="mono"
+            style={{
+              margin: "2px 0 0",
+              padding: "6px 8px",
+              background: "var(--bg-1)",
+              border: "1px solid var(--border)",
+              borderRadius: 4,
+              fontSize: 10.5,
+              color: "var(--fg)",
+              maxHeight: 160,
+              overflow: "auto",
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+            }}
+          >
+            {scan || "(none)"}
+          </pre>
+          {kb.length > 0 && (
+            <div style={{ marginTop: 6 }}>
+              <span style={{ color: "var(--fg-subtle)" }}>
+                baseline KB commands ({kb.length}):
+              </span>
+              <ul style={{ margin: "2px 0 0", paddingLeft: 16 }}>
+                {kb.map((c, i) => (
+                  <li key={i} className="mono" style={{ fontSize: 10.5, color: "var(--fg)" }}>
+                    {c.command}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          <div
+            style={{
+              marginTop: 8,
+              fontSize: 10,
+              fontStyle: "italic",
+              color: "var(--fg-subtle)",
+            }}
+          >
+            {cloud
+              ? "Plus a fixed system prompt. This is the only data that leaves your machine."
+              : "Plus a fixed system prompt. Stays on your configured local endpoint."}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Polish pass from the beta QA (P4–P6 + a11y). P3 (settings whitespace) was an a11y-snapshot artifact — visually fine — so left as-is.

## P5 — AI Suggest panel
- **Add to My Commands** per suggestion → POSTs to `/api/user-commands` scoped to the port (refresh to see it under MY COMMANDS).
- **Copy all safe (N)** bulk-copies non-intrusive suggestions.
- **SAFE/INTRUSIVE tooltip** explaining the risk.
- **AiContextPreview** disclosure on both Explain + Suggest — shows exactly what leaves the machine (port + scan output + baseline KB commands) before trusting a cloud provider.

## P4 — Warning contrast
`WarningBanner` swapped fixed `amber-200/400` for the theme-flipping `--risk-med` token, legible on light theme.

## P6 — Writeup focus
Opening the collapsible Writeup panel now scrolls the textarea into view + focuses it.

## a11y — Sidebar tabs
Active/Archived tabs get `aria-label` + `aria-pressed` so the count isn't read as "ACTIVE1".

## Verification
`tsc` clean · `eslint` clean · `next build` compiles · **593/593** tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)