### PR TITLE
chore: gitignore local SAST scan output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ next-env.d.ts
 # Local notes (untracked drafts)
 prd.md
 
+# Local SAST scan output (security-skill artifacts, not for release)
+/sast/
+
 # Local demo video bundle (not for release)
 /demo/
 


### PR DESCRIPTION
Ignore the local `sast/` directory (security-skill scan artifacts: architecture map + per-class results). They're working notes, not release content — keeping them ignored stops them from being accidentally staged into a feature commit (as nearly happened on #70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)