### PR TITLE
Opt-in web-augmented Explain (:online) + Markdown in Suggest "why"

### DIFF
--- a/app/api/ai/route.ts
+++ b/app/api/ai/route.ts
@@ -48,6 +48,8 @@ interface AiRequestBody {
   engagementId?: unknown;
   engagementLabel?: unknown;
   host?: unknown;
+  /** Opt-in web-augmented AI (OpenRouter `:online`); explicit per call. */
+  web?: unknown;
   context?: {
     port?: unknown;
     protocol?: unknown;
@@ -135,10 +137,21 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unknown task." }, { status: 400 });
   }
 
+  // Opt-in web-augmented AI: OpenRouter runs a web search when the model id
+  // carries a `:online` suffix. Gated to OpenRouter (the only provider that
+  // understands it) and to an explicit per-call `web: true` from the client —
+  // this sends search queries derived from scan data off-host, so it is never
+  // ambient. The `:online` model is recorded verbatim in the usage ledger, so
+  // its extra cost shows up distinctly in /settings/usage.
+  const webRequested = parsed.body.web === true;
+  const useWeb = webRequested && cfg.provider === "openrouter";
+  const effectiveModel =
+    useWeb && !cfg.model.endsWith(":online") ? `${cfg.model}:online` : cfg.model;
+
   const clientCfg = {
     baseUrl: cfg.baseUrl,
     apiKey: cfg.apiKey,
-    model: cfg.model,
+    model: effectiveModel,
   };
 
   // Best-effort usage ledger (analytics only — never breaks the AI response).
@@ -157,7 +170,7 @@ export async function POST(request: NextRequest) {
         host: asStr(parsed.body.host) ?? null,
         task: ledgerTask,
         provider: cfg.provider,
-        model: cfg.model,
+        model: effectiveModel,
         promptTokens: usage.promptTokens,
         completionTokens: usage.completionTokens,
         costUsd: usage.costUsd,

--- a/src/components/ExplainButton.tsx
+++ b/src/components/ExplainButton.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useState } from "react";
-import { Sparkles, Loader2, X } from "lucide-react";
+import { Sparkles, Loader2, X, Globe } from "lucide-react";
 import { useAiStatus } from "@/components/ai/useAiStatus";
 import { AiContextPreview } from "@/components/ai/AiContextPreview";
 import { AiErrorActions } from "@/components/ai/AiErrorActions";
@@ -35,14 +35,20 @@ export function ExplainButton(props: ExplainContext) {
   const [error, setError] = useState<string | null>(null);
   const [streaming, setStreaming] = useState(false);
   const [open, setOpen] = useState(false);
+  // Whether the last/active run used the web-augmented (:online) path.
+  const [webMode, setWebMode] = useState(false);
 
   // Hidden entirely unless the assistant is usable right now.
   if (!status || !status.enabled) return null;
 
-  async function run() {
+  // Web search only works on OpenRouter (the `:online` suffix); hide elsewhere.
+  const canWeb = status.provider === "openrouter";
+
+  async function run(web = false) {
     setOpen(true);
     setText("");
     setError(null);
+    setWebMode(web);
     setStreaming(true);
     try {
       const res = await fetch("/api/ai", {
@@ -52,6 +58,7 @@ export function ExplainButton(props: ExplainContext) {
           task: "explain",
           engagementId: props.engagementId,
           host: props.host ?? null,
+          web,
           context: {
             port: props.port,
             protocol: props.protocol ?? null,
@@ -82,32 +89,65 @@ export function ExplainButton(props: ExplainContext) {
 
   return (
     <div>
-      <button
-        type="button"
-        onClick={run}
-        disabled={streaming}
-        title={`Explain with AI (${status.provider}${status.cloud ? " · cloud" : " · local"})`}
-        style={{
-          display: "inline-flex",
-          alignItems: "center",
-          gap: 5,
-          padding: "4px 9px",
-          borderRadius: 5,
-          border: "1px solid var(--accent-border)",
-          background: "var(--accent-bg)",
-          color: "var(--accent)",
-          fontSize: 11.5,
-          fontWeight: 600,
-          cursor: streaming ? "wait" : "pointer",
-        }}
-      >
-        {streaming ? (
-          <Loader2 size={12} className="animate-spin" />
-        ) : (
-          <Sparkles size={12} />
+      <div style={{ display: "inline-flex", gap: 6 }}>
+        <button
+          type="button"
+          onClick={() => run(false)}
+          disabled={streaming}
+          title={`Explain with AI (${status.provider}${status.cloud ? " · cloud" : " · local"})`}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 5,
+            padding: "4px 9px",
+            borderRadius: 5,
+            border: "1px solid var(--accent-border)",
+            background: "var(--accent-bg)",
+            color: "var(--accent)",
+            fontSize: 11.5,
+            fontWeight: 600,
+            cursor: streaming ? "wait" : "pointer",
+          }}
+        >
+          {streaming && !webMode ? (
+            <Loader2 size={12} className="animate-spin" />
+          ) : (
+            <Sparkles size={12} />
+          )}
+          {streaming && !webMode ? "Explaining…" : "Explain"}
+        </button>
+        {/* Opt-in web-augmented explain (OpenRouter :online) — sends search
+            queries derived from scan data off-host, so it's a deliberate,
+            separate click, never the default. */}
+        {canWeb && (
+          <button
+            type="button"
+            onClick={() => run(true)}
+            disabled={streaming}
+            title="Web-augmented explain: also runs a live web search for current CVEs/exploits via OpenRouter (:online). Sends scan-derived queries off-host; costs extra."
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 5,
+              padding: "4px 9px",
+              borderRadius: 5,
+              border: "1px solid var(--border-strong)",
+              background: "var(--bg-2)",
+              color: "var(--fg-muted)",
+              fontSize: 11.5,
+              fontWeight: 600,
+              cursor: streaming ? "wait" : "pointer",
+            }}
+          >
+            {streaming && webMode ? (
+              <Loader2 size={12} className="animate-spin" />
+            ) : (
+              <Globe size={12} />
+            )}
+            {streaming && webMode ? "Searching…" : "Search web"}
+          </button>
         )}
-        {streaming ? "Explaining…" : "Explain"}
-      </button>
+      </div>
 
       {open && (
         <div
@@ -135,7 +175,9 @@ export function ExplainButton(props: ExplainContext) {
           >
             <span>
               AI EXPLANATION · {status.model}
+              {webMode ? ":online" : ""}
               {status.cloud ? " · cloud" : " · local"}
+              {webMode ? " · 🌐 web" : ""}
             </span>
             <button
               type="button"
@@ -154,7 +196,7 @@ export function ExplainButton(props: ExplainContext) {
           </div>
           <div style={{ padding: 10 }}>
             {error ? (
-              <AiErrorActions error={error} onRetry={run} />
+              <AiErrorActions error={error} onRetry={() => run(webMode)} />
             ) : (
               <div>
                 <Markdown text={text} />
@@ -172,6 +214,9 @@ export function ExplainButton(props: ExplainContext) {
               >
                 AI-generated — verify before acting. The model only describes
                 the scan; it does not run anything.
+                {webMode
+                  ? " Web-augmented: a live web search ran for this; treat sources critically."
+                  : ""}
               </div>
             )}
             <AiContextPreview

--- a/src/components/SuggestButton.tsx
+++ b/src/components/SuggestButton.tsx
@@ -15,6 +15,7 @@ import { useAiStatus } from "@/components/ai/useAiStatus";
 import { CopyButton } from "@/components/CopyButton";
 import { AiContextPreview } from "@/components/ai/AiContextPreview";
 import { AiErrorActions } from "@/components/ai/AiErrorActions";
+import { Markdown } from "@/components/ai/Markdown";
 
 interface Suggestion {
   command: string;
@@ -237,7 +238,7 @@ export function SuggestButton(props: SuggestContext) {
                           lineHeight: 1.5,
                         }}
                       >
-                        {s.why}
+                        <Markdown text={s.why} />
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
## Summary

Two AI-panel enhancements requested after the beta.18 review. (The third idea — game-plan effort/difficulty labels — is intentionally deferred to a later beta.)

### 1. Opt-in web-augmented Explain (`:online`)
OpenRouter runs a live web search when the model id carries a `:online` suffix — handy for "is there a current CVE / exploit / Metasploit module for this version?". Surfaced as a deliberate, per-call **"Search web"** button next to **Explain**, shown **only when the provider is OpenRouter**.

- **Never ambient.** The proxy appends `:online` only when an explicit `web: true` arrives *and* the provider is OpenRouter. No global toggle, one click at a time.
- **Honest about egress.** This sends scan-derived search queries off-host, so the button carries an egress warning, the panel header marks `:online · 🌐 web`, and the disclaimer notes a live search ran. Off by default; hidden under Exam Mode (AI is fully gated there anyway).
- **Cost is visible.** The `:online` model is recorded verbatim in the usage ledger, so its notably higher cost (web search + larger context — ~3k input tokens vs ~220 in testing) shows up as its own row in `/settings/usage`. No schema change.
- **Suggest stays KB-grounded** — web is Explain-only, by design.

### 2. Markdown in the Suggest card "why"
The suggestion rationale rendered raw, so backticked flags/paths and emphasis showed literally. Now rendered with the existing `Markdown` component — consistent with the Explain/Summary panels.

## Testing

- `npm test` → **612 passing**; `npm run typecheck`, `npm run lint:kb`, `npm run build` — all clean.
- Verified live (HTB Lame, real data): the "Search web" button appears only on OpenRouter; a web-augmented Explain returns content and records `openai/gpt-4o-mini:online` at ~$0.0056 vs ~$0.0001 for the plain call; the panel header shows `:online · 🌐 web`; and the Suggest "why" renders Markdown (no raw `**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
