### PR TITLE
fix(ai): ordered lists split by prose no longer restart at "1."

### DIFF
--- a/src/components/ai/Markdown.tsx
+++ b/src/components/ai/Markdown.tsx
@@ -90,6 +90,10 @@ export function Markdown({ text }: { text: string }) {
           return (
             <Tag
               key={i}
+              // Honor the source start number so an ordered list split by
+              // interleaved prose keeps counting (2., 3., …) instead of
+              // restarting at 1. on every fragment.
+              start={b.type === "ol" ? (b.start ?? 1) : undefined}
               style={{
                 margin: "4px 0 8px",
                 paddingLeft: 20,

--- a/src/components/ai/__tests__/markdown.test.ts
+++ b/src/components/ai/__tests__/markdown.test.ts
@@ -11,11 +11,30 @@ describe("ai Markdown parseBlocks", () => {
     expect(parseBlocks("### Plan")).toEqual([{ type: "h", level: 3, text: "Plan" }]);
   });
 
-  it("groups consecutive numbered items into one ordered list", () => {
+  it("groups consecutive numbered items into one ordered list (start 1)", () => {
     const b = parseBlocks("1. first\n2. second\n3. third");
     expect(b).toHaveLength(1);
     expect(b[0].type).toBe("ol");
     expect(b[0].items).toEqual(["first", "second", "third"]);
+    expect(b[0].start).toBe(1);
+  });
+
+  it("ordered list split by prose keeps the source numbers (no 1. 1. 1.)", () => {
+    // The cross-host summary interleaves a "Reason:" line between numbered steps.
+    const b = parseBlocks(
+      "1. Host A — do this\nReason: because\n2. Host B — do that\nReason: because\n3. Host C — and this",
+    );
+    const ols = b.filter((x) => x.type === "ol");
+    expect(ols.map((o) => o.start)).toEqual([1, 2, 3]);
+    expect(ols.map((o) => o.items![0])).toEqual([
+      "Host A — do this",
+      "Host B — do that",
+      "Host C — and this",
+    ]);
+  });
+
+  it("honors an explicit start offset for a contiguous list", () => {
+    expect(parseBlocks("5. five\n6. six")[0].start).toBe(5);
   });
 
   it("groups bullet items into one unordered list", () => {

--- a/src/components/ai/markdown-parse.ts
+++ b/src/components/ai/markdown-parse.ts
@@ -8,6 +8,10 @@ export interface MdBlock {
   level?: number;
   items?: string[]; // for lists
   text?: string; // for h / p
+  /** First item's source number for an ordered list (so a list split by
+   *  interleaved prose — e.g. a "Reason:" line between steps — still renders
+   *  2., 3., … instead of restarting at 1. each time). */
+  start?: number;
 }
 
 /** Group lines into headings / lists / paragraphs. */
@@ -25,7 +29,7 @@ export function parseBlocks(src: string): MdBlock[] {
     const line = raw.trimEnd();
     const h = line.match(/^(#{1,6})\s+(.*)$/);
     const ul = line.match(/^\s*[-*]\s+(.*)$/);
-    const ol = line.match(/^\s*\d+[.)]\s+(.*)$/);
+    const ol = line.match(/^\s*(\d+)[.)]\s+(.*)$/);
     if (h) {
       flushPara();
       blocks.push({ type: "h", level: h[1].length, text: h[2] });
@@ -36,9 +40,11 @@ export function parseBlocks(src: string): MdBlock[] {
       else blocks.push({ type: "ul", items: [ul[1]] });
     } else if (ol) {
       flushPara();
+      const num = parseInt(ol[1], 10);
+      const text = ol[2];
       const last = blocks[blocks.length - 1];
-      if (last?.type === "ol") last.items!.push(ol[1]);
-      else blocks.push({ type: "ol", items: [ol[1]] });
+      if (last?.type === "ol") last.items!.push(text);
+      else blocks.push({ type: "ol", items: [text], start: num });
     } else if (!line.trim()) {
       flushPara();
     } else {


### PR DESCRIPTION
## Summary

Fixes a Markdown rendering bug in the AI panels: a numbered list interrupted by prose rendered every item as **"1."**.

The cross-host summary (and any "game plan") puts a `Reason:` line between numbered steps:

```
1. Host A — do this
Reason: …
2. Host B — do that
Reason: …
```

The interleaved prose ended each `<ol>`, so every step became its own single-item `<ol>` — and a fresh `<ol>` restarts at 1, so the UI showed `1.` `1.` `1.` …

## Fix

Capture each ordered-list item's **source number** on the block and emit `<ol start={N}>`, so steps render `1.`, `2.`, `3.`, … even when split by prose. Contiguous lists are unaffected. Adds parser regression tests for the split-by-prose case.

## Testing
`npm test` → 614 passing (adds 2 markdown-parse cases); `npm run typecheck`, `npm run lint:kb`, `npm run build` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
